### PR TITLE
Fixes test api script.

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 
 from aiohttp import ClientSession
-import api.api  # pylint: disable=no-name-in-module
+import api.api as api
 from api.apitypes import SolixParmType  # pylint: disable=no-name-in-module
 import common
 


### PR DESCRIPTION
Amazing work @thomluther!

For me the test_api was not running because api.AnkerSolixApi does not exist. 
I needed to do api.api.AnkerSolixApi instead. 

This fixes this by importing differently the api.

Let me know, whether this is an issue only on my site.

Best,
@maxspahn