### PR TITLE
feat: charging_pv_svc endpoints

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1344,3 +1344,91 @@ class AnkerSolixApi(AnkerSolixBaseApi):
                 "post", API_ENDPOINTS["get_upgrade_record"], json=data
             )
         return resp.get("data") or {}
+
+
+    async def get_device_pv_status(self, deviceSn: str, fromFile: bool = False) -> dict:
+        """Gets the current pv status for an inverter device
+
+        Example data:
+        {"sn": "JJY4QAVAFKT9", "power": 169, "status": 1}
+        """
+
+        data = {"sns": deviceSn}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['get_device_pv_status']}_{deviceSn}.json"
+           )
+        else:
+            resp = await self.apisession.request(
+                "post", API_ENDPOINTS["get_device_pv_status"], json=data
+            )
+        response = resp.get("data") or {}
+
+        statuses = response.get("pvStatuses") or []
+        return statuses[0] if len(statuses) > 0 else None
+
+    async def get_device_pv_total_statistics(self, deviceSn: str, fromFile: bool = False) -> dict:
+        """Gets the total pv statistic data for an inverter device
+
+        Example data:
+        {"energy": 66.15, "energyUnit": "kWh", "reductionCo2": 66, "reductionCo2Unit": "kg",
+        "saveMoney": 0, "saveMoneyUnit": "\u20ac", "powerConfig": "800W", "powerPopUpFlag": 0}
+        """
+        data = {"sn": deviceSn}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['get_device_pv_total_statistics']}_{deviceSn}.json"
+           )
+        else:
+            resp = await self.apisession.request(
+                "post", API_ENDPOINTS["get_device_pv_total_statistics"], json=data
+            )
+
+        return resp.get("data") or {}
+
+    async def get_device_pv_statistics(
+            self,
+            deviceSn: str,
+            type: str,
+            start: str,
+            end: str,
+            fromFile: bool = False,
+    ) -> dict:
+        """Get pv statistics data for an inverter device on a daily, weekly, monthly or yearly basis
+
+        - type is either day, week, month or year
+        - start is the day (YYYY-MM-DD), month (YYYY-MM) or year (YYYY) in question
+        - end is the last day of a week (YYYY-MM-DD), if the type is week
+
+        Example data (type year):
+        {'curve': [], 'energy': [{'money': 0, 'energy': 0, 'index': 1}, {'money': 0, 'energy': 0, 'index': 2},
+        {'money': 0, 'energy': 15.35, 'index': 3}, {'money': 0, 'energy': 50.81, 'index': 4},
+        {'money': 0, 'energy': 0, 'index': 5}, {'money': 0, 'energy': 0, 'index': 6},
+        {'money': 0, 'energy': 0, 'index': 7}, {'money': 0, 'energy': 0, 'index': 8},
+        {'money': 0, 'energy': 0, 'index': 9}, {'money': 0, 'energy': 0, 'index': 10},
+        {'money': 0, 'energy': 0, 'index': 11}, {'money': 0, 'energy': 0, 'index': 12}],
+        'energyUnit': 'kWh', 'solarGeneraion': 66.15, 'money': 0, 'moneyUnit': '', 'loadPercent': '',
+        'ppsPercent': '', 'generationTime': 0, 'maxPower': 0}
+        """
+
+        data = {
+            "sn": deviceSn,
+            "type": type,
+            "start": start,
+            "end": end,
+            "version": "1",
+        }
+
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['get_device_pv_statistics']}_{type}_{deviceSn}.json"
+           )
+        else:
+            resp = await self.apisession.request(
+                "post", API_ENDPOINTS["get_device_pv_statistics"], json=data
+            )
+
+        return resp.get("data") or {}

--- a/api/apitypes.py
+++ b/api/apitypes.py
@@ -139,6 +139,9 @@ API_ENDPOINTS = {
     "get_currency_list": "power_service/v1/currency/get_list",  # get list of supported currencies for power sites
     "get_ota_batch": "app/ota/batch/check_update",  # get OTA information and latest version for device SN list, works also for shared accounts, but data only received for owner accounts
     "get_mqtt_info": "app/devicemanage/get_user_mqtt_info",  # post method to list mqtt server and certificates for a site, not explored or used
+    "get_device_pv_status": "charging_pv_svc/getPvStatus", # post method get the current activity status and power generation of a device
+    "get_device_pv_total_statistics": "charging_pv_svc/getPvTotalStatistics", # post method the get total statistics (generated power, saved money, saved CO2) of a device
+    "get_device_pv_statistics": "charging_pv_svc/statisticsPv", # post method to get detailed statistics on a daily, weekly, monthly or yearly basis
 }
 
 """Following are the Anker Power/Solix Cloud API charging_energy_service endpoints known so far. They are used for Power Panels."""
@@ -379,6 +382,10 @@ API_FILEPREFIXES = {
     "charging_get_configs": "charging_configs",
     "charging_get_sns": "charging_sns",
     "charging_get_monetary_units": "charging_monetary_units",
+    # charging_pv_svc endpoint file prefixes
+    "get_device_pv_status": "device_pv_status",
+    "get_device_pv_total_statistics": "device_pv_total_statistics",
+    "get_device_pv_statistics": "device_pv_statistics",
     # charging_energy_service endpoint file prefixes
     "hes_get_product_info": "hes_product_info",
     "hes_get_heat_pump_plan": "hes_heat_pump_plan",

--- a/examples/MI80_Standalone/api_account.json
+++ b/examples/MI80_Standalone/api_account.json
@@ -1,0 +1,12 @@
+{
+  "type": "account",
+  "email": "anonymous-1@domain.com",
+  "nickname": "******",
+  "country": "DE",
+  "server": "https://ankerpower-api-eu.anker.com",
+  "use_files": false,
+  "sites_poll_time": "2025-04-19 16:19:35",
+  "sites_poll_seconds": 0.136,
+  "requests_last_min": 33,
+  "requests_last_hour": 33
+}

--- a/examples/MI80_Standalone/api_devices.json
+++ b/examples/MI80_Standalone/api_devices.json
@@ -1,0 +1,17 @@
+{
+  "JJY4QAVAFKT9": {
+    "device_sn": "JJY4QAVAFKT9",
+    "device_pn": "A5143",
+    "type": "inverter",
+    "bt_ble_mac": "E377907D0C1D",
+    "name": "MI80 Microinverter(BLE)",
+    "alias": "MI80 Microinverter(BLE)",
+    "wifi_online": false,
+    "wifi_name": "wifi-network-1",
+    "charge": false,
+    "bws_surplus": "0",
+    "sw_version": "v0.0.1",
+    "tag": "",
+    "rssi": ""
+  }
+}

--- a/examples/MI80_Standalone/auto_upgrade.json
+++ b/examples/MI80_Standalone/auto_upgrade.json
@@ -1,0 +1,9 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "main_switch": false,
+    "device_list": null
+  },
+  "trace_id": "9c3f22aeeccdf9ae8badbabd6cd2e54c"
+}

--- a/examples/MI80_Standalone/bind_devices.json
+++ b/examples/MI80_Standalone/bind_devices.json
@@ -1,0 +1,35 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "data": [
+      {
+        "device_sn": "JJY4QAVAFKT9",
+        "product_code": "A5143",
+        "bt_ble_id": "E377907D0C1D",
+        "bt_ble_mac": "E377907D0C1D",
+        "device_name": "MI80 Microinverter(BLE)",
+        "alias_name": "MI80 Microinverter(BLE)",
+        "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/0f8e0ca7-dda9-4e70-940d-fe08e1fc89ea/picl_A5143_normal.png",
+        "link_time": 1742648615,
+        "wifi_online": false,
+        "wifi_name": "wifi-network-1",
+        "relate_type": [
+          "ble"
+        ],
+        "charge": false,
+        "bws_surplus": 0,
+        "device_sw_version": "v0.0.1",
+        "has_manual": false,
+        "hes_data": null,
+        "tag": "",
+        "tag_img": "",
+        "platform_tag": "",
+        "platform_logo": "",
+        "rssi": "",
+        "intgr_device": null
+      }
+    ]
+  },
+  "trace_id": "8caf40f2f046b2aaf02f43bcfbe510ac"
+}

--- a/examples/MI80_Standalone/charging_devices.json
+++ b/examples/MI80_Standalone/charging_devices.json
@@ -1,0 +1,9 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "device_list": null,
+    "guide_txt": ""
+  },
+  "trace_id": "ffbcc5afd5da93d2f442bcccefd1431f"
+}

--- a/examples/MI80_Standalone/config.json
+++ b/examples/MI80_Standalone/config.json
@@ -1,0 +1,10 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "conf_list": [],
+    "start_config_id": 0,
+    "last": false
+  },
+  "trace_id": "eebc064bcceb0e30eceeda6f910ce99d"
+}

--- a/examples/MI80_Standalone/currency_list.json
+++ b/examples/MI80_Standalone/currency_list.json
@@ -1,0 +1,25 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "currency_list": [
+      {
+        "symbol": "$",
+        "name": "USD"
+      },
+      {
+        "symbol": "\u20ac",
+        "name": "EUR"
+      },
+      {
+        "symbol": "z\u0142",
+        "name": "PLN"
+      }
+    ],
+    "default_currency": {
+      "symbol": "\u20ac",
+      "name": "EUR"
+    }
+  },
+  "trace_id": "3fb0df09ceabcb4c5ce5bc08dfbd9916"
+}

--- a/examples/MI80_Standalone/device_attrs_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_attrs_JJY4QAVAFKT9.json
@@ -1,0 +1,9 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "device_sn": "JJY4QAVAFKT9",
+    "attributes": {}
+  },
+  "trace_id": "8ef7f636006f405988d3dea124022eab"
+}

--- a/examples/MI80_Standalone/device_pv_statistics_day_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_pv_statistics_day_JJY4QAVAFKT9.json
@@ -1,0 +1,2034 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "curve": [
+      {
+        "power": 0,
+        "time": "00:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "00:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "01:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "02:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "03:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "04:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "05:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "06:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "06:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "06:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "06:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "06:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 6,
+        "time": "06:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 4,
+        "time": "06:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 6,
+        "time": "06:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 11,
+        "time": "06:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 14,
+        "time": "06:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 18,
+        "time": "06:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 26,
+        "time": "06:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 29,
+        "time": "07:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 23,
+        "time": "07:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 19,
+        "time": "07:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 14,
+        "time": "07:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 14,
+        "time": "07:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 20,
+        "time": "07:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 17,
+        "time": "07:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 33,
+        "time": "07:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 54,
+        "time": "07:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 57,
+        "time": "07:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 61,
+        "time": "07:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 66,
+        "time": "07:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 77,
+        "time": "08:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 94,
+        "time": "08:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 98,
+        "time": "08:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 114,
+        "time": "08:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 136,
+        "time": "08:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 129,
+        "time": "08:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 111,
+        "time": "08:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 93,
+        "time": "08:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 77,
+        "time": "08:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 86,
+        "time": "08:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 102,
+        "time": "08:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 95,
+        "time": "08:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 79,
+        "time": "09:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 88,
+        "time": "09:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 100,
+        "time": "09:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 98,
+        "time": "09:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 99,
+        "time": "09:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 107,
+        "time": "09:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 80,
+        "time": "09:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 71,
+        "time": "09:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 126,
+        "time": "09:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 129,
+        "time": "09:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 102,
+        "time": "09:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 105,
+        "time": "09:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 96,
+        "time": "10:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 87,
+        "time": "10:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 88,
+        "time": "10:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 96,
+        "time": "10:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 94,
+        "time": "10:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 105,
+        "time": "10:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 124,
+        "time": "10:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 137,
+        "time": "10:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 174,
+        "time": "10:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 177,
+        "time": "10:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 196,
+        "time": "10:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 186,
+        "time": "10:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 171,
+        "time": "11:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 148,
+        "time": "11:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 160,
+        "time": "11:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 116,
+        "time": "11:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 120,
+        "time": "11:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 152,
+        "time": "11:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 151,
+        "time": "11:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 135,
+        "time": "11:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 102,
+        "time": "11:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 109,
+        "time": "11:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 115,
+        "time": "11:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 87,
+        "time": "11:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 46,
+        "time": "12:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 38,
+        "time": "12:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 43,
+        "time": "12:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 59,
+        "time": "12:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 68,
+        "time": "12:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 67,
+        "time": "12:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 60,
+        "time": "12:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 49,
+        "time": "12:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 55,
+        "time": "12:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 51,
+        "time": "12:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 51,
+        "time": "12:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 55,
+        "time": "12:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 78,
+        "time": "13:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 83,
+        "time": "13:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 89,
+        "time": "13:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 103,
+        "time": "13:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 95,
+        "time": "13:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 93,
+        "time": "13:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 98,
+        "time": "13:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 116,
+        "time": "13:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 122,
+        "time": "13:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 116,
+        "time": "13:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 119,
+        "time": "13:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 120,
+        "time": "13:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 122,
+        "time": "14:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 118,
+        "time": "14:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 106,
+        "time": "14:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 101,
+        "time": "14:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 99,
+        "time": "14:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 87,
+        "time": "14:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 88,
+        "time": "14:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 103,
+        "time": "14:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 109,
+        "time": "14:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 108,
+        "time": "14:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 121,
+        "time": "14:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 123,
+        "time": "14:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 122,
+        "time": "15:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 115,
+        "time": "15:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 107,
+        "time": "15:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 105,
+        "time": "15:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 111,
+        "time": "15:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 150,
+        "time": "15:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 184,
+        "time": "15:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 189,
+        "time": "15:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 186,
+        "time": "15:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 201,
+        "time": "15:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 243,
+        "time": "15:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 227,
+        "time": "15:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 208,
+        "time": "16:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 177,
+        "time": "16:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 151,
+        "time": "16:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 163,
+        "time": "16:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "16:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "17:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "18:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "19:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "20:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "21:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "22:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:00",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:05",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:10",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:15",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:20",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:25",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:30",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:35",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:40",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:45",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:50",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      },
+      {
+        "power": 0,
+        "time": "23:55",
+        "valuePtr": null,
+        "isFix": false,
+        "isFuture": false
+      }
+    ],
+    "energy": [],
+    "energyUnit": "kWh",
+    "solarGeneraion": 0.99,
+    "money": 0,
+    "moneyUnit": "",
+    "loadPercent": "",
+    "ppsPercent": "",
+    "generationTime": 0,
+    "maxPower": 0
+  },
+  "trace_id": "abf0c3ac4ef64c737cd4bcfe4fa5dc69"
+}

--- a/examples/MI80_Standalone/device_pv_statistics_month_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_pv_statistics_month_JJY4QAVAFKT9.json
@@ -1,0 +1,168 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "curve": [],
+    "energy": [
+      {
+        "money": 0,
+        "energy": 2.46,
+        "index": 1
+      },
+      {
+        "money": 0,
+        "energy": 3.55,
+        "index": 2
+      },
+      {
+        "money": 0,
+        "energy": 3.63,
+        "index": 3
+      },
+      {
+        "money": 0,
+        "energy": 3.6,
+        "index": 4
+      },
+      {
+        "money": 0,
+        "energy": 3.5,
+        "index": 5
+      },
+      {
+        "money": 0,
+        "energy": 2.85,
+        "index": 6
+      },
+      {
+        "money": 0,
+        "energy": 3.32,
+        "index": 7
+      },
+      {
+        "money": 0,
+        "energy": 2.08,
+        "index": 8
+      },
+      {
+        "money": 0,
+        "energy": 2.45,
+        "index": 9
+      },
+      {
+        "money": 0,
+        "energy": 2.38,
+        "index": 10
+      },
+      {
+        "money": 0,
+        "energy": 2.78,
+        "index": 11
+      },
+      {
+        "money": 0,
+        "energy": 2.83,
+        "index": 12
+      },
+      {
+        "money": 0,
+        "energy": 2.39,
+        "index": 13
+      },
+      {
+        "money": 0,
+        "energy": 3.38,
+        "index": 14
+      },
+      {
+        "money": 0,
+        "energy": 2.26,
+        "index": 15
+      },
+      {
+        "money": 0,
+        "energy": 3.94,
+        "index": 16
+      },
+      {
+        "money": 0,
+        "energy": 1.81,
+        "index": 17
+      },
+      {
+        "money": 0,
+        "energy": 0.59,
+        "index": 18
+      },
+      {
+        "money": 0,
+        "energy": 0.99,
+        "index": 19
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 20
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 21
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 22
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 23
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 24
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 25
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 26
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 27
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 28
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 29
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 30
+      }
+    ],
+    "energyUnit": "kWh",
+    "solarGeneraion": 50.81,
+    "money": 0,
+    "moneyUnit": "",
+    "loadPercent": "",
+    "ppsPercent": "",
+    "generationTime": 0,
+    "maxPower": 0
+  },
+  "trace_id": "e6449f6b4ddcaa7dbdce45df1cad60e8"
+}

--- a/examples/MI80_Standalone/device_pv_statistics_week_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_pv_statistics_week_JJY4QAVAFKT9.json
@@ -1,0 +1,53 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "curve": [],
+    "energy": [
+      {
+        "money": 0,
+        "energy": 3.38,
+        "index": 1
+      },
+      {
+        "money": 0,
+        "energy": 2.26,
+        "index": 2
+      },
+      {
+        "money": 0,
+        "energy": 3.94,
+        "index": 3
+      },
+      {
+        "money": 0,
+        "energy": 1.81,
+        "index": 4
+      },
+      {
+        "money": 0,
+        "energy": 0.59,
+        "index": 5
+      },
+      {
+        "money": 0,
+        "energy": 0.99,
+        "index": 6
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 7
+      }
+    ],
+    "energyUnit": "kWh",
+    "solarGeneraion": 12.98,
+    "money": 0,
+    "moneyUnit": "",
+    "loadPercent": "",
+    "ppsPercent": "",
+    "generationTime": 0,
+    "maxPower": 0
+  },
+  "trace_id": "e3a327db9e9050da4f3a3c2c5569ba49"
+}

--- a/examples/MI80_Standalone/device_pv_statistics_year_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_pv_statistics_year_JJY4QAVAFKT9.json
@@ -1,0 +1,78 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "curve": [],
+    "energy": [
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 1
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 2
+      },
+      {
+        "money": 0,
+        "energy": 15.35,
+        "index": 3
+      },
+      {
+        "money": 0,
+        "energy": 50.81,
+        "index": 4
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 5
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 6
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 7
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 8
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 9
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 10
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 11
+      },
+      {
+        "money": 0,
+        "energy": 0,
+        "index": 12
+      }
+    ],
+    "energyUnit": "kWh",
+    "solarGeneraion": 66.15,
+    "money": 0,
+    "moneyUnit": "",
+    "loadPercent": "",
+    "ppsPercent": "",
+    "generationTime": 0,
+    "maxPower": 0
+  },
+  "trace_id": "ccc05fbdf2bbeac1ec8bcef7f43ae0e9"
+}

--- a/examples/MI80_Standalone/device_pv_status_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_pv_status_JJY4QAVAFKT9.json
@@ -1,0 +1,14 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "pvStatuses": [
+      {
+        "sn": "JJY4QAVAFKT9",
+        "power": 169,
+        "status": 1
+      }
+    ]
+  },
+  "trace_id": "b0e0e5ee9c7a80ee95dca275b4adcf4b"
+}

--- a/examples/MI80_Standalone/device_pv_total_statistics_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/device_pv_total_statistics_JJY4QAVAFKT9.json
@@ -1,0 +1,15 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "energy": 66.15,
+    "energyUnit": "kWh",
+    "reductionCo2": 66,
+    "reductionCo2Unit": "kg",
+    "saveMoney": 0,
+    "saveMoneyUnit": "\u20ac",
+    "powerConfig": "800W",
+    "powerPopUpFlag": 0
+  },
+  "trace_id": "3befefbeef9faa0d5adc29e623a2ca88"
+}

--- a/examples/MI80_Standalone/get_token.json
+++ b/examples/MI80_Standalone/get_token.json
@@ -1,0 +1,8 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "token": "IrjtEjFWdPbQeIbLkFRwdusHCUGNVizHUUhkGtRHiyDfFPFUCnCMzUeFZKPtwzhfMiMqXtVMhufWFCFNQQPShVpceZNlMripDWBKoYGNoTCoOcaXEQrqCnEBVMQdXPguUHgocFmzsSMSJOUGvZxYNvnI"
+  },
+  "trace_id": "ef7b07d7120d12eef7fc41ffbb8ec265"
+}

--- a/examples/MI80_Standalone/homepage.json
+++ b/examples/MI80_Standalone/homepage.json
@@ -1,0 +1,12 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "site_list": [],
+    "solar_list": [],
+    "pps_list": [],
+    "solarbank_list": [],
+    "powerpanel_list": []
+  },
+  "trace_id": "c47bb5c1d6fc6045dedd6ea539da7c81"
+}

--- a/examples/MI80_Standalone/list_accessories.json
+++ b/examples/MI80_Standalone/list_accessories.json
@@ -1,0 +1,25 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": [
+    {
+      "name": "E1600 0W Output Switch",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/10/iot-admin/EPBsJ3a5JyMGqA1j/picl_A17Y0_normal.png",
+      "index": 1,
+      "product_code": "A17Y0",
+      "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/10/iot-admin/7FhPIwMwf9BD0UPm/A17Y0_guide.png",
+      "net_guideline": "Click the button and the sync icon will quick blinking.",
+      "p_codes": null
+    },
+    {
+      "name": "SOLIX Generator Input Adapter",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2025/03/12/iot-admin/MSbarAEDpCywk0HP/picl_A17D0_normal%20%281%29.png",
+      "index": 2,
+      "product_code": "A17D0",
+      "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2025/03/12/iot-admin/c0QnZTBsWMl4yEDp/A1790_A1790P_guide.gif",
+      "net_guideline": "Connect SOLIX F3800 Plus and generator respectively",
+      "p_codes": null
+    }
+  ],
+  "trace_id": "c271c93dfec6f6ce2acaba4196e4b54d"
+}

--- a/examples/MI80_Standalone/list_products.json
+++ b/examples/MI80_Standalone/list_products.json
@@ -1,0 +1,1128 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": [
+    {
+      "name": "Portable Power Station",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/449e84f8-c65b-44a8-a18a-94ce188a077d/picl_addadevice_list_PoweredClooer.png",
+      "index": 1,
+      "products": [
+        {
+          "name": "767 PowerHouse (SOLIX F2000)",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/0a83138f-3289-49b3-9427-72f2bddfd909/picl_A1780_normal.png",
+          "index": 0,
+          "product_code": "A1780",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/d354b92c-2f94-4195-ade3-fec66ae2ba21/A1780_guide_mini.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "X2Y",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/cpofBN8hOYIRtuv3/picl_A1780_US_CA_normal.png"
+            },
+            {
+              "p_code": "4QY",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/cpofBN8hOYIRtuv3/picl_A1780_US_CA_normal.png"
+            },
+            {
+              "p_code": "X5F",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/vN9f5fordpHpoCov/picl_A1780_JP_normal.png"
+            },
+            {
+              "p_code": "ZWR",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/PpkLNwHPg9ZAJ4pV/picl_A1780_UK_normal.png"
+            },
+            {
+              "p_code": "ZX4",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/0sdkUE3iquZ1GhxM/picl_A1780_EU_normal.png"
+            },
+            {
+              "p_code": "25N",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/hh31QGNyZkBDEyWA/picl_A1780_AU_normal.png"
+            },
+            {
+              "p_code": "25P",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/0a83138f-3289-49b3-9427-72f2bddfd909/picl_A1780_normal.png"
+            },
+            {
+              "p_code": "25M",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/0a83138f-3289-49b3-9427-72f2bddfd909/picl_A1780_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "F1200 (Bluetooth)",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/17dcfc76-e4fd-45d4-9f78-9b2da8d61a9e/picl_A1770up_normal.png",
+          "index": 2,
+          "product_code": "A1770",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/441ff6dc-4397-4fe2-a38e-9e6c8d5ee2e7/A1770_guide_mini.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "3M6",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/LoSPtdzniwk8CRBI/picl_A1770up_US_JP_normal.png"
+            },
+            {
+              "p_code": "3LV",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/xHWikcbYvrFGuX76/picl_A1770up_UK_normal.png"
+            },
+            {
+              "p_code": "3M7",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/7h0Ripz5q0jAC1OC/picl_A1770up_EU_normal.png"
+            },
+            {
+              "p_code": "3LW",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/QhSOlQu8WmuYc7YJ/picl_A1770up_AU_normal.png"
+            },
+            {
+              "p_code": "539",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/LoSPtdzniwk8CRBI/picl_A1770up_US_JP_normal.png"
+            },
+            {
+              "p_code": "5N7",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/17dcfc76-e4fd-45d4-9f78-9b2da8d61a9e/picl_A1770up_normal.png"
+            },
+            {
+              "p_code": "ZZ2",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/17dcfc76-e4fd-45d4-9f78-9b2da8d61a9e/picl_A1770up_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "F1200 (Bluetooth and WLAN)",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/2e013920-fbde-4e67-a0ce-24fa1b97fcc8/picl_A1771_normal.png",
+          "index": 3,
+          "product_code": "A1771",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/8a36f285-34c2-4a2b-86f7-e2a07e6fb0a1/A1771_guide_mini.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": []
+        },
+        {
+          "name": "SOLIX F2600",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2023/09/07/iot-admin/J4Km2jVe42dADzVR/picl_A1781_normal.png",
+          "index": 4,
+          "product_code": "A1781",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/02/05/iot-admin/9TuuwYmzaRJrxreZ/A1781_guide_mini.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "3NM",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/8OtCyfqXiCADlOZH/picl_A1781_US_normal.png"
+            },
+            {
+              "p_code": "3NQ",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/NmWP6XfYTeejcQyB/picl_A1781_JP_CA_normal.png"
+            },
+            {
+              "p_code": "3NN",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/ALof0MoBxuLzOwAq/picl_A1781_UK_SA_normal.png"
+            },
+            {
+              "p_code": "7NX",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/ALof0MoBxuLzOwAq/picl_A1781_UK_SA_normal.png"
+            },
+            {
+              "p_code": "3NP",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/2VjsXXRGpXf2i2YG/picl_A1781_EU_normal.png"
+            },
+            {
+              "p_code": "7R2",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/4PU5rYiMMdSmXc9D/picl_A1781_ZA_normal.png"
+            },
+            {
+              "p_code": "3PD",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/11/04/iot-admin/KlOdeJl1qLZbviMW/picl_A1781_AU_normal.png"
+            },
+            {
+              "p_code": "3PE",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2023/09/07/iot-admin/J4Km2jVe42dADzVR/picl_A1781_normal.png"
+            },
+            {
+              "p_code": "69G",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/NmWP6XfYTeejcQyB/picl_A1781_JP_CA_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX F1500",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2023/09/07/iot-admin/CZktwI2UiNEkYQQ9/picl_A1772_normal.png",
+          "index": 5,
+          "product_code": "A1772",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/02/05/iot-admin/Ffqk9p0eibAK3FM8/A1772_guide_mini.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "6TZ",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/t7NLT2BAD8ZwQBwn/picl_A1772_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "75Z",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/t7NLT2BAD8ZwQBwn/picl_A1772_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "7CU",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/t7NLT2BAD8ZwQBwn/picl_A1772_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "79W",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/4RtI5Ci9TH7yoHRp/picl_A1772_EU_normal.png"
+            },
+            {
+              "p_code": "7TP",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/4RtI5Ci9TH7yoHRp/picl_A1772_EU_normal.png"
+            },
+            {
+              "p_code": "6XX",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/bnWQJbEsUGf44V37/picl_A1772_EU_normal.png"
+            },
+            {
+              "p_code": "6UA",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/09/07/iot-admin/BHJA6uah647z8APU/picl_A1772_ZA_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C800",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/dRoEV8kVfeDuuCLx/picl_A1753_normal.png",
+          "index": 5,
+          "product_code": "A1753",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/ERTIBar5QkLFK3jX/A1753_guide.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "5ZE",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/1BuXZDk9tasIM8JD/picl_A1753_AU_normal.png"
+            },
+            {
+              "p_code": "5ZD",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/KlcjiwizKcbvXAsm/picl_A1753_EU_normal.png"
+            },
+            {
+              "p_code": "5ZA",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Gwrlj4TpedGsIthq/picl_A1753_UK_SA_normal.png"
+            },
+            {
+              "p_code": "6TY",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Gwrlj4TpedGsIthq/picl_A1753_UK_SA_normal.png"
+            },
+            {
+              "p_code": "5XG",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/izmuDukqQAIZurV4/picl_A1753_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZC",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/izmuDukqQAIZurV4/picl_A1753_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "6TU",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/izmuDukqQAIZurV4/picl_A1753_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZT",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/8i0ZGBKeaFsq5kDP/picl_A1753_ZA_normal.png"
+            },
+            {
+              "p_code": "EC0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/1BuXZDk9tasIM8JD/picl_A1753_AU_normal.png"
+            },
+            {
+              "p_code": "DZB",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/KlcjiwizKcbvXAsm/picl_A1753_EU_normal.png"
+            },
+            {
+              "p_code": "EA0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Gwrlj4TpedGsIthq/picl_A1753_UK_SA_normal.png"
+            },
+            {
+              "p_code": "DZ1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/izmuDukqQAIZurV4/picl_A1753_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "EAB",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/izmuDukqQAIZurV4/picl_A1753_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "EH0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/izmuDukqQAIZurV4/picl_A1753_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZF",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/dRoEV8kVfeDuuCLx/picl_A1753_normal.png"
+            },
+            {
+              "p_code": "CLC",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/1BuXZDk9tasIM8JD/picl_A1753_AU_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX F3800",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2023/11/22/iot-admin/F2Mil5M4JgRthIDo/picl_A1790_normal.png",
+          "index": 6,
+          "product_code": "A1790",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/02/05/iot-admin/G19LjloX2NaefYXx/A1790_guide.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "744",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2023/11/27/iot-admin/dGQ2PRvjmyayYgvi/picl_A1790_US_normal.png"
+            },
+            {
+              "p_code": "746",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2023/11/27/iot-admin/dGQ2PRvjmyayYgvi/picl_A1790_US_normal.png"
+            },
+            {
+              "p_code": "BH3",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2023/11/27/iot-admin/dGQ2PRvjmyayYgvi/picl_A1790_US_normal.png"
+            },
+            {
+              "p_code": "6RT",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2023/11/27/iot-admin/dGQ2PRvjmyayYgvi/picl_A1790_US_normal.png"
+            },
+            {
+              "p_code": "6S6",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2023/11/27/iot-admin/dGQ2PRvjmyayYgvi/picl_A1790_US_normal.png"
+            },
+            {
+              "p_code": "73U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2023/11/27/iot-admin/dGQ2PRvjmyayYgvi/picl_A1790_US_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C800 Plus",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/35Fnuy3Aw7fJKFyY/picl_A1754_normal.png",
+          "index": 6,
+          "product_code": "A1754",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/G52LpEL8kG090J0C/A1754_guide.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "5ZK",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/wHF22nIAvRN2p16d/picl_A1754_AU_normal.png"
+            },
+            {
+              "p_code": "5ZG",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/oAwwynMH4HvctkzI/picl_A1754_EU_norma.png"
+            },
+            {
+              "p_code": "5ZH",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Ce3S3sf0eFJct3v8/picl_A1754_UK_SA_normal.png"
+            },
+            {
+              "p_code": "75U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Ce3S3sf0eFJct3v8/picl_A1754_UK_SA_normal.png"
+            },
+            {
+              "p_code": "5YU",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZJ",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "6U6",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZS",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/bl2WPqLrrVn0P0LS/picl_A1754_ZA_normal.png"
+            },
+            {
+              "p_code": "L0K",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/wHF22nIAvRN2p16d/picl_A1754_AU_normal.png"
+            },
+            {
+              "p_code": "EE0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/oAwwynMH4HvctkzI/picl_A1754_EU_norma.png"
+            },
+            {
+              "p_code": "EF0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Ce3S3sf0eFJct3v8/picl_A1754_UK_SA_normal.png"
+            },
+            {
+              "p_code": "EJ8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Ce3S3sf0eFJct3v8/picl_A1754_UK_SA_normal.png"
+            },
+            {
+              "p_code": "ED8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "EF8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "NT1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "EJ0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/UlI5sabXIGhDnsAF/picl_A1754_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "EG8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/bl2WPqLrrVn0P0LS/picl_A1754_ZA_normal.png"
+            },
+            {
+              "p_code": "5ZR",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/35Fnuy3Aw7fJKFyY/picl_A1754_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C1000(X)",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/b4VVnVyVA7KkQTQR/picl_A1761_normal.png",
+          "index": 6,
+          "product_code": "A1761",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/2IFuTRLP2FifOYSM/A1761_guide.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "9FD",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5YX",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZV",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "AA1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "766",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "A3K",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "5ZU",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/foqGmI4VYX2ixALy/picl_A1761_UK_SA_normal.png"
+            },
+            {
+              "p_code": "9FE",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/foqGmI4VYX2ixALy/picl_A1761_UK_SA_normal.png"
+            },
+            {
+              "p_code": "6TV",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/foqGmI4VYX2ixALy/picl_A1761_UK_SA_normal.png"
+            },
+            {
+              "p_code": "5ZZ",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/6sidVbYQxpVDiHcJ/picl_A1761_TW_normal.png"
+            },
+            {
+              "p_code": "6NX",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Z4Ws9hl4d8VCOYac/picl_A1761_EU_normal.png"
+            },
+            {
+              "p_code": "9FQ",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Z4Ws9hl4d8VCOYac/picl_A1761_EU_normal.png"
+            },
+            {
+              "p_code": "5ZX",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/omKbP9Thaor9aRLr/picl_A1761_AU_normal.png"
+            },
+            {
+              "p_code": "5ZW",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/RkukTyV1oXfYP8GB/picl_A1761_ZA_normal.png"
+            },
+            {
+              "p_code": "E0Y",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "DQ0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "E1H",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "E1C",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/foqGmI4VYX2ixALy/picl_A1761_UK_SA_normal.png"
+            },
+            {
+              "p_code": "E1K",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/foqGmI4VYX2ixALy/picl_A1761_UK_SA_normal.png"
+            },
+            {
+              "p_code": "E1B",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Z4Ws9hl4d8VCOYac/picl_A1761_EU_normal.png"
+            },
+            {
+              "p_code": "E1F",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/omKbP9Thaor9aRLr/picl_A1761_AU_normal.png"
+            },
+            {
+              "p_code": "E8M",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/RkukTyV1oXfYP8GB/picl_A1761_ZA_normal.png"
+            },
+            {
+              "p_code": "5ZY",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/b4VVnVyVA7KkQTQR/picl_A1761_normal.png"
+            },
+            {
+              "p_code": "E1D",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/17/iot-admin/b4VVnVyVA7KkQTQR/picl_A1761_normal.png"
+            },
+            {
+              "p_code": "9FH",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "ETE",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "D6U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "CKX",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "CLA",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "2JR",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/17/iot-admin/Kn4wEN6T2hwjq8R2/picl_A1761_US_JP_CA_normal.png"
+            },
+            {
+              "p_code": "05U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/04/07/iot-admin/0y7PGlrf0O32nHMJ/picl_A1762_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C300",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/07/10/iot-admin/VcfD1ZjJ4UjR0iQN/picl_A1722_normal.png",
+          "index": 7,
+          "product_code": "A1722",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/McsDNRl1nchHp72D/A1722_guide%20%283%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "SB1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "SFB",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "SB7",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "0HM",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "SB3",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/gQF2E9g3jkjYzGDb/picl_A1722_UK_SA_normal.png"
+            },
+            {
+              "p_code": "SB5",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/sHnxp9lKUqPE1P7U/picl_A1722_EU_normal.png"
+            },
+            {
+              "p_code": "SBD",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/aGfgGHkNElqKWkMq/picl_A1722_AU_normal.png"
+            },
+            {
+              "p_code": "SG1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/5zv0AWYfC9MpxYon/picl_A1722_UK_SA_normal.png"
+            },
+            {
+              "p_code": "GQR",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "FKM",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "P2M",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "G9A",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/HKGuvnOCQ2x4b9zj/picl_A1722_US_JP_CA_normal%20%283%29.png"
+            },
+            {
+              "p_code": "FAA",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/sHnxp9lKUqPE1P7U/picl_A1722_EU_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C300 DC",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/07/10/iot-admin/38YZzjgar8iYpvDb/picl_A1726_normal%20%281%29.png",
+          "index": 8,
+          "product_code": "A1726",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/AXUf0EPzZpeZrYKZ/A1726_guide%20%282%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "UW0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            },
+            {
+              "p_code": "136",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            },
+            {
+              "p_code": "0LD",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            },
+            {
+              "p_code": "0HP",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            },
+            {
+              "p_code": "CYM",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            },
+            {
+              "p_code": "2JU",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            },
+            {
+              "p_code": "FAD",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/qG1yGm1nB79hfHvV/picl_A1726_normal%20%282%29.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C800X",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png",
+          "index": 10,
+          "product_code": "A1755",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/5lES6f0b5FChvkzJ/A1755_guide.gif",
+          "net_guideline": "Press the IoT button and the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "D81",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/24/iot-admin/AP6CbkHAcPii4sSb/picl_A1755_UK_normal.png"
+            },
+            {
+              "p_code": "D89",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/01/24/iot-admin/GOIoVcTOwsJjOZm1/picl_A1755_EU_normal.png"
+            },
+            {
+              "p_code": "D7B",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png"
+            },
+            {
+              "p_code": "D82",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png"
+            },
+            {
+              "p_code": "D84",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png"
+            },
+            {
+              "p_code": "D87",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png"
+            },
+            {
+              "p_code": "D5U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png"
+            },
+            {
+              "p_code": "FRT",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/01/24/iot-admin/thrm1ruROE3ZhF5j/picl_A1755_EU_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C300X",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/07/23/iot-admin/HA5iBrATvOzn1qFU/picl_A1723_A1725_US_JP_CA_normal%20%281%29.png",
+          "index": 13,
+          "product_code": "A1723",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/vE3GONsrejt15b3K/A1723_A1725_guide%20%282%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "SBH",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/07/23/iot-admin/arSCdjeXXavmnHAG/picl_A1723_A1725_US_JP_CA_normal%20%281%29.png"
+            },
+            {
+              "p_code": "SEB",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/07/23/iot-admin/arSCdjeXXavmnHAG/picl_A1723_A1725_US_JP_CA_normal%20%281%29.png"
+            },
+            {
+              "p_code": "SBJ",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/r73H13renVHd4YK1/picl_A1723_A1725_UK_SA_normal.png"
+            },
+            {
+              "p_code": "SBK",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/kareMnKInL7MIqtV/picl_A1723_A1725_EU_normal%20%281%29.png"
+            },
+            {
+              "p_code": "FYT",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/07/23/iot-admin/arSCdjeXXavmnHAG/picl_A1723_A1725_US_JP_CA_normal%20%281%29.png"
+            }
+          ]
+        },
+        {
+          "name": "767 Power House (SOLIX F2000) with WLAN",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/05/08/iot-admin/wcBAOqrriCbGd03z/picl_A1780_normal%20%281%29.png",
+          "index": 20,
+          "product_code": "A1780P",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/05/28/iot-admin/XG4Wu10niw1rwMAF/A1780p_guide.gif",
+          "net_guideline": "Press the IoT button until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "RP8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/11/iot-admin/phHXfpTmRIk1Ikn6/picl_A1780P_EU_normal.png"
+            },
+            {
+              "p_code": "S0X",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/11/iot-admin/61a8d3UMleIEdHjQ/picl_A1780P_UK_normal.png"
+            },
+            {
+              "p_code": "S18",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/11/iot-admin/ffEFPIQCNS9mdsH9/picl_A1780P_JP_normal.png"
+            },
+            {
+              "p_code": "S0Y",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/11/iot-admin/8yO3V0VorUMyDjFd/picl_A1780P_AU_normal.png"
+            },
+            {
+              "p_code": "S0U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/11/iot-admin/bHDOqNqbAL0dHpxO/picl_A1780P_US_CA_normal%20%281%29.png"
+            },
+            {
+              "p_code": "S1A",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/11/iot-admin/ZXhe3da2GMp9Hmhc/picl_A1780P_US_CA_normal%202.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C200X DC",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/14/iot-admin/mfmEjC69NWt9muj9/picl_A1729_normal.png",
+          "index": 20,
+          "product_code": "A1729",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/jqIN1NBYIFW4X2zQ/A1729_guide%20%281%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "ZG8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/WY8mc18xKGXMglPK/picl_A1729_normal%20%281%29.png"
+            },
+            {
+              "p_code": "ZJB",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/WY8mc18xKGXMglPK/picl_A1729_normal%20%281%29.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C300X DC",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/08/26/iot-admin/NJlCUlM9BiVByp8l/picl_A1728_normal.png",
+          "index": 20,
+          "product_code": "A1728",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/frBCH3qAYjB6sarz/A1728_guide%20%281%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "ZF8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/m0DFMCyhXgjpC75y/picl_A1728_normal%20%281%29.png"
+            },
+            {
+              "p_code": "ZJ1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/m0DFMCyhXgjpC75y/picl_A1728_normal%20%281%29.png"
+            },
+            {
+              "p_code": "ZG0",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/m0DFMCyhXgjpC75y/picl_A1728_normal%20%281%29.png"
+            },
+            {
+              "p_code": "FXR",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/m0DFMCyhXgjpC75y/picl_A1728_normal%20%281%29.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C200(X)",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/09/10/iot-admin/RIrnP4F33XUmvZOT/picl_A1723_A1725_normal.png",
+          "index": 27,
+          "product_code": "A1725",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/PEhcGrXG7IjLIbDg/A1723_A1725_guide%20%282%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "SBV",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/09/13/iot-admin/8CndwaEyiyEGgsLn/picl_A1723_A1725_normal.png"
+            },
+            {
+              "p_code": "SBY",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/09/13/iot-admin/8CndwaEyiyEGgsLn/picl_A1723_A1725_normal.png"
+            },
+            {
+              "p_code": "SF8",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/09/13/iot-admin/8CndwaEyiyEGgsLn/picl_A1723_A1725_normal.png"
+            },
+            {
+              "p_code": "SF1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/bi3stIn3yrGqEPEl/picl_A1723_A1725_UK_SA_normal.png"
+            },
+            {
+              "p_code": "FYS",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/09/13/iot-admin/8CndwaEyiyEGgsLn/picl_A1723_A1725_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX C200 DC",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/09/10/iot-admin/6jgdx9H7kg4XaujT/picl_A1727_normal.png",
+          "index": 28,
+          "product_code": "A1727",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/10/18/iot-admin/XVnzwtd6tKvAZMhU/A1727_guide%20%281%29.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "WVB",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/91Ob5SGOA12U0tQl/picl_A1727_normal%20%281%29.png"
+            },
+            {
+              "p_code": "0QV",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/91Ob5SGOA12U0tQl/picl_A1727_normal%20%281%29.png"
+            },
+            {
+              "p_code": "0LF",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/91Ob5SGOA12U0tQl/picl_A1727_normal%20%281%29.png"
+            },
+            {
+              "p_code": "0HR",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/91Ob5SGOA12U0tQl/picl_A1727_normal%20%281%29.png"
+            },
+            {
+              "p_code": "D63",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/91Ob5SGOA12U0tQl/picl_A1727_normal%20%281%29.png"
+            },
+            {
+              "p_code": "2K6",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/10/18/iot-admin/91Ob5SGOA12U0tQl/picl_A1727_normal%20%281%29.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX F3800 Plus",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/12/23/iot-admin/QW83dlPEOw6qA043/picl_A1790P_normal.png",
+          "index": 29,
+          "product_code": "A1790P",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/12/23/iot-admin/yRidtwelo3lFU3X5/A1790P_guide.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "T29",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/12/23/iot-admin/3kYJ3zLOnSw69Qm1/picl_A1790P_normal.png"
+            },
+            {
+              "p_code": "T27",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/12/23/iot-admin/3kYJ3zLOnSw69Qm1/picl_A1790P_normal.png"
+            },
+            {
+              "p_code": "C2C",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/12/23/iot-admin/3kYJ3zLOnSw69Qm1/picl_A1790P_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "Portable Power Station 1000",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/12/23/iot-admin/q3rpCWdMtQ3Pqffh/picl_A1762_normal.png",
+          "index": 30,
+          "product_code": "A1762",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/12/23/iot-admin/Z7rCkQnH9GxskEhE/A1762_guide.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "05U",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/12/23/iot-admin/oL6YoEXVu1dq3tAz/picl_A1762_normal.png"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Balcony Solar Power System",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/29f0b6a3-6ba5-40cb-b1b8-94cf39784433/20230731-103020.jpeg",
+      "index": 2,
+      "products": [
+        {
+          "name": "MI60 Microinverter",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/2e60fc1a-f1c2-4574-8e00-a50689c87f72/picl_A5140_normal.png",
+          "index": 1,
+          "product_code": "A5140",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/e75905fc-4cce-4533-bece-8bd7f9464e6f/A5140_guide.png",
+          "net_guideline": "<div style=\"margin-bottom:12px;\"><font face=\"DingNextLTProRegular\" style=\"font-size: 16px\";>The Schuko cable should not be connected to your home grid yet!</font></div><br>\n\n<div style=\"margin-bottom:12px;\"><font face=\"DingNextLTProRegular\" style=\"font-size: 16px\";>Step 1: Please make sure the DC power supply (cable solar panel to inverter) is connected.</font></div><br>\n\n<div style=\"margin-bottom:12px;\"><font face=\"DingNextLTProRegular\" style=\"font-size: 16px\";>Step 2: Wait 90 seconds when the indicator light of the inverter</font><font face=\"DingNextLTProRegular\" color=\"#00A9E0\" style=\"font-size: 16px\"> blink red</font>.</div><br>\n\n<div style=\"margin-bottom:12px;\"><font face=\"DingNextLTProRegular\" style=\"font-size: 16px\";>Step 3: Connect your phone to the Wi-Fi of the Microinverter</font><font face=\"DingNextLTProRegular\" color=\"#00A9E0\" style=\"font-size: 16px\"> MI-XXXXXXXX</font><font face=\"DingNextLTProRegular\" style=\"font-size: 16px\";> and return to the Anker App.</font></div><br>\n\n<div style=\"margin-bottom:12px;\"><font face=\"DingNextLTProRegular\" style=\"font-size: 16px\";>Password:</font><font face=\"DingNextLTProRegular\" color=\"#00A9E0\" style=\"font-size: 16px\">12345678</font></div>",
+          "p_codes": []
+        },
+        {
+          "name": "Solarbank 2 E1600 Pro",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/05/24/iot-admin/5iJoq1dk63i47HuR/picl_A17C1_normal%281%29.png",
+          "index": 1,
+          "product_code": "A17C1",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/05/24/iot-admin/xCw8DYNcDGk35wxs/A17C1_guide.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the IoT button starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "A17C13Z1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/05/24/iot-admin/SC9Wa8mzqhkLFMjt/picl_A17C1_normal.png"
+            },
+            {
+              "p_code": "A17C1IZ1",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/05/24/iot-admin/SC9Wa8mzqhkLFMjt/picl_A17C1_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "MI80 Microinverter(BLE)",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/0f8e0ca7-dda9-4e70-940d-fe08e1fc89ea/picl_A5143_normal.png",
+          "index": 2,
+          "product_code": "A5143",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/4780fd1e-5e33-4a89-8028-f26da5084b4a/A5143_guide_mini.gif",
+          "net_guideline": "Please check:<br>1. If the device is plugged into a power outlet?<br>2. The inverter's indicator light is blinking green?",
+          "p_codes": []
+        },
+        {
+          "name": "Solarbank E1600",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/e9478c2d-e665-4d84-95d7-dd4844f82055/20230719-144818.png",
+          "index": 2,
+          "product_code": "A17C0",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/a901a1c3-a2ba-46ec-8eb6-f644eb29489b/A17C0_guide_generic.gif",
+          "net_guideline": "Press the button and the IoT button is blinking green light.",
+          "p_codes": [
+            {
+              "p_code": "6Y6",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/2ZacNVApQvHbpyFe/picl_A17C0_normal.png"
+            },
+            {
+              "p_code": "V6Y",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/2ZacNVApQvHbpyFe/picl_A17C0_normal.png"
+            },
+            {
+              "p_code": "T90",
+              "img_url": "https://public-aiot-fra-prod.s3.eu-central-1.amazonaws.com/anker-power/public/banner/2023/08/21/iot-admin/2ZacNVApQvHbpyFe/picl_A17C0_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "Solarbank 2 E1600 AC",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/11/11/iot-admin/NycsbknWijoZcv1b/output.lin.png",
+          "index": 3,
+          "product_code": "A17C2",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/11/11/iot-admin/J8NZ7XicfgK05mLA/output.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the IoT button starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "T78",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/11/11/iot-admin/84TjgOa161MOH05b/output.lin.png"
+            }
+          ]
+        },
+        {
+          "name": "Solarbank 2 E1600 Plus",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/06/24/iot-admin/3cVAFo62HO58vAdl/picl_A17C3_normal.png",
+          "index": 20,
+          "product_code": "A17C3",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/06/24/iot-admin/hfV8IpSHr6VDUsaZ/A17C1_A17C3_guide.gif",
+          "net_guideline": "Press the IoT button for 2 seconds until the IoT button starts flashing.",
+          "p_codes": [
+            {
+              "p_code": "N90",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/25/iot-admin/dseGYbHEgOYyp6Uk/picl_A17C3_normal.png"
+            },
+            {
+              "p_code": "N8Q",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/06/25/iot-admin/3bQH8P8ROaYwokAr/picl_A17C3_normal.png"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Powered Cooler",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/dd9bcf41-f4e6-4b9a-8b6c-d808a67c1b43/picl_addadevice_list_PoweredCoolor.png",
+      "index": 3,
+      "products": [
+        {
+          "name": "Powered Cooler 30",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/fac7b94e-c02a-44b1-8836-a78cb938c50e/picl_A17A0_normal.png",
+          "index": 1,
+          "product_code": "A17A0",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/ec718705-d15d-401b-90dc-65853138c9dc/A17A0_A17A1_guide.png",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": []
+        },
+        {
+          "name": "Powered Cooler 40",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/a9d58f40-3bac-4972-b0dc-dd2d2a4d6106/picl_A17A1_normal.png",
+          "index": 2,
+          "product_code": "A17A1",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/1104b4cc-9a6e-4ff5-a069-9586853cc492/A17A0_A17A1_guide.png",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": []
+        },
+        {
+          "name": "Powered Cooler 50",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/435287b1-9dcf-45ac-b363-67b92a0f6c42/picl_A17A2_normal.png",
+          "index": 3,
+          "product_code": "A17A2",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/a9ea0a57-bc30-460e-8573-d7020a5e6afc/A17A2_guide.png",
+          "net_guideline": "Press the IoT button for 2 seconds until the logo starts flashing.",
+          "p_codes": []
+        },
+        {
+          "name": "SOLIX Everfrost 2 58L",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2025/02/17/iot-admin/YIpI9EuYtXk6CzlA/picl_A17A5_normal%20%281%29.png",
+          "index": 29,
+          "product_code": "A17A5",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2025/03/25/iot-admin/x6ka0X1RZRckM1la/A17A5_guide%20%284%29.gif",
+          "net_guideline": "Press and hold the button on the device for 2 seconds. When the Bluetooth logo starts flashing, you can connect the device with the Anker APP.",
+          "p_codes": [
+            {
+              "p_code": "DJCW",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJ62",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJ7M",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DHVV",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DHVU",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DK7P",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJVP",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/FvuFv5lTZrGYXWvu/picl_A17A5_normal%20%281%29.png"
+            }
+          ]
+        },
+        {
+          "name": "SOLIX Everfrost 2 40L",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2025/02/17/iot-admin/qXKe8Y2GHMdAOWau/picl_A17A4_normal%20%281%29.png",
+          "index": 29,
+          "product_code": "A17A4",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2025/03/25/iot-admin/wGv0DGXd1sQoHf6z/A17A3_A17A4_guide.gif",
+          "net_guideline": "Press and hold the button on the device for 2 seconds. When the Bluetooth logo starts flashing, you can connect the device with the Anker APP.",
+          "p_codes": [
+            {
+              "p_code": "DHVT",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DHY3",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJ7L",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJ5P",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJD6",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DJVQ",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            },
+            {
+              "p_code": "DK9Q",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2025/02/17/iot-admin/gk3biCNQgE6JOj5f/picl_A17A4_normal%20%281%29.png"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Accessory",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/07/26/iot-admin/Rb96n0Ut9xtNydgT/picl_addadevice_list_accessory.png",
+      "index": 6,
+      "products": [
+        {
+          "name": "Smart Meter",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/05/24/iot-admin/opwTD5izbjD9DjKB/picl_A17X7_normal.png",
+          "index": 1,
+          "product_code": "A17X7",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/05/24/iot-admin/kMAaRkW9d5uRMgy8/A17X7_gudie.gif",
+          "net_guideline": "After the smart meter is turned on, if the device communicates normally, the signal indicator light will flash blue and it is in the Bluetooth broadcast state.\nIf the blue indicator light does not flash, please press and hold the button for 7 seconds and wait until the blue indicator light flashes to perform Bluetooth network configuration.",
+          "p_codes": [
+            {
+              "p_code": "A17X7311",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/05/24/iot-admin/cWPdWhpvOnwnY4ka/picl_A17X7_normal.png"
+            }
+          ]
+        },
+        {
+          "name": "Smart Plug",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/07/23/iot-admin/jvwLiu0cOHjYMCwV/picl_A17X8_normal.png",
+          "index": 10,
+          "product_code": "A17X8",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/07/23/iot-admin/zal3bGIYPO7zF4K5/A17X8_gudie.gif",
+          "net_guideline": "When the indicator light flashes green, the device is in network configuration mode.\nIf the indicator light stays green, please long press the button to put the device into network configuration mode.",
+          "p_codes": [
+            {
+              "p_code": "T8L",
+              "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/banner/2024/07/23/iot-admin/C2SCknadUtPo4fZY/picl_A17X8_normal.png"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Charging Station",
+      "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/08/08/iot-admin/OQv9OSKzIQMamtg3/picl_addadevice_list_A2345_A91B2-JPN.png",
+      "index": 7,
+      "products": [
+        {
+          "name": "250W Prime Charger",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/08/08/iot-admin/0lJm9TW1Kmizv9OM/picl_A2345.png",
+          "index": 1,
+          "product_code": "A2345",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/08/08/iot-admin/2Dzj0Kl9GmuaFRFA/A2345_guide.gif",
+          "net_guideline": "Select the Wi-Fi option on the device setting, and a Wi-Fi flashing icon will appear on the device screen.",
+          "p_codes": []
+        },
+        {
+          "name": "240W Charging Station",
+          "img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/08/08/iot-admin/37vPAkEWziYkHFJk/picl_A91B2_Japan.png",
+          "index": 2,
+          "product_code": "A91B2",
+          "net_img_url": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/2024/08/08/iot-admin/TL4AXfpHYQbW2gKG/A911B2-JPN.gif",
+          "net_guideline": "Press and hold the Display Button for 5 seconds until a Wi-Fi flashing icon appears on the device screen.",
+          "p_codes": []
+        }
+      ]
+    }
+  ],
+  "trace_id": "4adbda90bcff1b52fdee78aa9dbe3464"
+}

--- a/examples/MI80_Standalone/list_site_rules.json
+++ b/examples/MI80_Standalone/list_site_rules.json
@@ -1,0 +1,225 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "rule_list": [
+      {
+        "power_site_type": 1,
+        "main_device_models": [
+          "A5143"
+        ],
+        "device_models": [
+          "A5143",
+          "A1771"
+        ],
+        "can_empty_site": false,
+        "quantity_min_limit_map": {
+          "A1771": 1,
+          "A5143": 1
+        },
+        "quantity_max_limit_map": {
+          "A1771": 2,
+          "A5143": 1
+        }
+      },
+      {
+        "power_site_type": 2,
+        "main_device_models": [
+          "A17C0"
+        ],
+        "device_models": [
+          "A17C0",
+          "A5143",
+          "A1771"
+        ],
+        "can_empty_site": false,
+        "quantity_min_limit_map": {
+          "A17C0": 1
+        },
+        "quantity_max_limit_map": {
+          "A1771": 2,
+          "A17C0": 2,
+          "A5143": 1
+        }
+      },
+      {
+        "power_site_type": 4,
+        "main_device_models": [
+          "A17B1"
+        ],
+        "device_models": [
+          "A17B1"
+        ],
+        "can_empty_site": true,
+        "quantity_min_limit_map": null,
+        "quantity_max_limit_map": {
+          "A17B1": 1
+        }
+      },
+      {
+        "power_site_type": 5,
+        "main_device_models": [
+          "A17C1"
+        ],
+        "device_models": [
+          "A17C1",
+          "A17X7",
+          "SHEM3",
+          "SHEMP3",
+          "A17X8",
+          "A17C0"
+        ],
+        "can_empty_site": true,
+        "quantity_min_limit_map": null,
+        "quantity_max_limit_map": {
+          "A17C0": 2,
+          "A17C1": 1,
+          "A17X7": 1,
+          "A17X8": 6,
+          "SHEM3": 1,
+          "SHEMP3": 1
+        }
+      },
+      {
+        "power_site_type": 6,
+        "main_device_models": [
+          "A5341"
+        ],
+        "device_models": [
+          "A5341",
+          "A5101",
+          "A5220"
+        ],
+        "can_empty_site": false,
+        "quantity_min_limit_map": {
+          "A5341": 1
+        },
+        "quantity_max_limit_map": {
+          "A5341": 1
+        }
+      },
+      {
+        "power_site_type": 7,
+        "main_device_models": [
+          "A5101"
+        ],
+        "device_models": [
+          "A5101",
+          "A5220"
+        ],
+        "can_empty_site": false,
+        "quantity_min_limit_map": {
+          "A5101": 1
+        },
+        "quantity_max_limit_map": {
+          "A5101": 6
+        }
+      },
+      {
+        "power_site_type": 8,
+        "main_device_models": [
+          "A5102"
+        ],
+        "device_models": [
+          "A5102",
+          "A5220"
+        ],
+        "can_empty_site": false,
+        "quantity_min_limit_map": {
+          "A5102": 1
+        },
+        "quantity_max_limit_map": {
+          "A5102": 6
+        }
+      },
+      {
+        "power_site_type": 9,
+        "main_device_models": [
+          "A5103"
+        ],
+        "device_models": [
+          "A5103",
+          "A5220"
+        ],
+        "can_empty_site": false,
+        "quantity_min_limit_map": {
+          "A5103": 1
+        },
+        "quantity_max_limit_map": {
+          "A5103": 6
+        }
+      },
+      {
+        "power_site_type": 10,
+        "main_device_models": [
+          "A17C3"
+        ],
+        "device_models": [
+          "A17C3",
+          "A17X7",
+          "SHEM3",
+          "SHEMP3",
+          "A17X8",
+          "A17C0"
+        ],
+        "can_empty_site": true,
+        "quantity_min_limit_map": null,
+        "quantity_max_limit_map": {
+          "A17C0": 2,
+          "A17C3": 1,
+          "A17X7": 1,
+          "A17X8": 6,
+          "SHEM3": 1,
+          "SHEMP3": 1
+        }
+      },
+      {
+        "power_site_type": 11,
+        "main_device_models": [
+          "A17C2"
+        ],
+        "device_models": [
+          "A17C2",
+          "A17X7",
+          "A17X8",
+          "SHEM3",
+          "SHEMP3"
+        ],
+        "can_empty_site": true,
+        "quantity_min_limit_map": null,
+        "quantity_max_limit_map": {
+          "A17C2": 1,
+          "A17X7": 1,
+          "A17X8": 6,
+          "SHEM3": 1,
+          "SHEMP3": 1
+        }
+      },
+      {
+        "power_site_type": 12,
+        "main_device_models": [
+          "A17C5"
+        ],
+        "device_models": [
+          "A17C5",
+          "A17X7",
+          "SHEM3",
+          "SHEMP3",
+          "A17X8",
+          "SHPPS"
+        ],
+        "can_empty_site": true,
+        "quantity_min_limit_map": null,
+        "quantity_max_limit_map": {
+          "A17C5": 1,
+          "A17X7": 1,
+          "A17X8": 6,
+          "SHEM3": 1,
+          "SHEMP3": 1,
+          "SHPPS": 6
+        }
+      }
+    ]
+  },
+  "trace_id": "a4c67e38b85bf576dfce72f1c4c3937a"
+}

--- a/examples/MI80_Standalone/list_third_platforms.json
+++ b/examples/MI80_Standalone/list_third_platforms.json
@@ -1,0 +1,8 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "data": []
+  },
+  "trace_id": "b5ecd4bf271e55cafbad84c06651b072"
+}

--- a/examples/MI80_Standalone/message_unread.json
+++ b/examples/MI80_Standalone/message_unread.json
@@ -1,0 +1,10 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "has_unread_msg": false,
+    "system_msg": false,
+    "device_msg": false
+  },
+  "trace_id": "49555276bdce5a8c24bf51691f9a5aac"
+}

--- a/examples/MI80_Standalone/ota_batch.json
+++ b/examples/MI80_Standalone/ota_batch.json
@@ -1,0 +1,26 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "update_infos": [
+      {
+        "device_sn": "JJY4QAVAFKT9",
+        "need_update": false,
+        "upgrade_type": 0,
+        "lastPackage": {
+          "product_code": "",
+          "product_component": "",
+          "version": "",
+          "is_forced": false,
+          "md5": "",
+          "url": "",
+          "size": 0
+        },
+        "change_log": "",
+        "current_version": "",
+        "children": null
+      }
+    ]
+  },
+  "trace_id": "ff3894b7ae299fc73defcd7a3090e435"
+}

--- a/examples/MI80_Standalone/setup.txt
+++ b/examples/MI80_Standalone/setup.txt
@@ -1,0 +1,3 @@
+SETUP:
+MI60 Inverter
+No system / site in Anker App

--- a/examples/MI80_Standalone/shelly_status.json
+++ b/examples/MI80_Standalone/shelly_status.json
@@ -1,0 +1,8 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "op_list": []
+  },
+  "trace_id": "c5b009e3bb0f934f0c1dd3f5cdbcb3a4"
+}

--- a/examples/MI80_Standalone/site_list.json
+++ b/examples/MI80_Standalone/site_list.json
@@ -1,0 +1,8 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "site_list": []
+  },
+  "trace_id": "ebde90820bedab8a7b72fefdb632fa89"
+}

--- a/examples/MI80_Standalone/upgrade_record_1_JJY4QAVAFKT9.json
+++ b/examples/MI80_Standalone/upgrade_record_1_JJY4QAVAFKT9.json
@@ -1,0 +1,10 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "device_sn": "JJY4QAVAFKT9",
+    "site_id": "",
+    "upgrade_record_list": []
+  },
+  "trace_id": "bf4fd54f62f099539bf3926b5accca43"
+}

--- a/examples/MI80_Standalone/user_devices.json
+++ b/examples/MI80_Standalone/user_devices.json
@@ -1,0 +1,26 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "solar_list": [
+      {
+        "device_sn": "JJY4QAVAFKT9",
+        "device_name": "MI80 Microinverter(BLE)",
+        "device_img": "https://public-aiot-fra-prod.s3.dualstack.eu-central-1.amazonaws.com/anker-power/public/product/anker-power/0f8e0ca7-dda9-4e70-940d-fe08e1fc89ea/picl_A5143_normal.png",
+        "bind_site_status": "0",
+        "generate_power": "",
+        "power_unit": "",
+        "status": "0",
+        "wireless_type": "2",
+        "device_pn": "A5143",
+        "main_version": ""
+      }
+    ],
+    "pps_list": [],
+    "solarbank_list": [],
+    "powerpanel_list": [],
+    "grid_list": [],
+    "smartplug_list": []
+  },
+  "trace_id": "e9d4dadead4265f673dca5dde5fdbac1"
+}

--- a/inverter_monitor.py
+++ b/inverter_monitor.py
@@ -1,0 +1,168 @@
+
+import asyncio
+from datetime import datetime, timedelta
+import logging
+from pathlib import Path
+
+from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientError
+from api import api, errors
+import common
+
+# use Console logger from common module
+CONSOLE: logging.Logger = common.CONSOLE
+
+
+def get_subfolders(folder: str | Path) -> list:
+    """Get the full pathname of all subfolder for given folder as list."""
+    if isinstance(folder, str):
+        folder: Path = Path(folder)
+    if folder.is_dir():
+        return [f.resolve() for f in folder.iterdir() if f.is_dir()]
+    return []
+
+
+async def main() -> bool:
+    CONSOLE.info("Inverter Monitor:")
+
+    # get list of possible example and export folders to test the monitor against
+    example_list: list = get_subfolders(
+        Path(__file__).parent / "examples"
+    ) + get_subfolders(Path(__file__).parent / "exports")
+
+    # let user select to use example or live data
+    CONSOLE.info("\nSelect the input source for the monitor:")
+    CONSOLE.info("(0) Real time from Anker cloud")
+    for idx, filename in enumerate(example_list, start=1):
+        CONSOLE.info("(%s) %s", idx, filename)
+    CONSOLE.info("(q) Quit")
+
+    selection = input(f"Input Source number (0-{len(example_list)}) or [q]uit: ")
+    if (
+            selection.upper() in ["Q", "QUIT"]
+            or not selection.isdigit()
+            or int(selection) < 0
+            or int(selection) > len(example_list)
+    ):
+        return False
+
+    if (selection := int(selection)) == 0:
+        use_file = False
+        test_folder = None
+    else:
+        use_file = True
+        test_folder = example_list[selection - 1]
+
+    try:
+        async with ClientSession() as websession:
+            user = "" if use_file else common.user()
+            if not use_file:
+                CONSOLE.info("Trying Api authentication for user %s...", user)
+            myapi = api.AnkerSolixApi(
+                user,
+                "" if use_file else common.password(),
+                "" if use_file else common.country(),
+                websession,
+                CONSOLE,
+            )
+            if use_file:
+                # set the correct test folder for Api
+                myapi.testDir(test_folder)
+            elif await myapi.async_authenticate():
+                CONSOLE.info("Anker Cloud authentication: OK")
+            else:
+                # Login validation will be done during first API call
+                CONSOLE.info("Anker Cloud authentication: CACHED")
+
+            # query user for device to be monitored
+            CONSOLE.info("Getting device list...")
+            devices = (await myapi.get_user_devices(fromFile=use_file)).get(
+                "solar_list"
+            ) or []
+            CONSOLE.info("Select which device to monitor:")
+            devices_names = [
+                (
+                    ", ".join(
+                        [
+                            str(d.get("device_name")),
+                            str(d.get("device_sn")),
+                        ]
+                    )
+                )
+                for d in devices
+            ]
+
+            for idx, sitename in enumerate(devices_names):
+                CONSOLE.info("(%s) %s", idx, sitename)
+            selection = input(
+                f"Enter device number (0-{len(devices_names) - 1}): "
+            )
+            if not selection.isdigit() or 0 < int(selection) >= len(devices_names):
+                CONSOLE.error("Invalid selection")
+                return False
+
+            device_sn = devices[int(selection)].get("device_sn")
+
+            # query user for refresh rate
+            refresh = 30
+            resp = input(
+                "How many seconds refresh interval should be used? (5-600, default: 30): "
+            )
+            if not resp:
+                response = 30
+            elif resp.isdigit() and 5 >= int(resp) <= 600:
+                refresh = int(resp)
+            else :
+                CONSOLE.error("Invalid selection")
+                return False
+
+            # ask which endpoint limit should be applied
+            selection = input(
+                f"Enter Api endpoint limit for request throttling (1-50, 0 = disabled) [Default: {myapi.apisession.endpointLimit()}]: "
+            )
+            if selection.isdigit() and 0 <= int(selection) <= 50:
+                myapi.apisession.endpointLimit(int(selection))
+
+            # Monitor device
+            next_refresh: datetime = datetime.now().astimezone()
+
+            while True:
+                now = datetime.now().astimezone()
+                if next_refresh > now:
+                    await asyncio.sleep(1)
+                    continue
+
+                next_refresh = now + timedelta(seconds=refresh)
+
+                device_status = await myapi.get_device_pv_status(
+                    deviceSn=device_sn,
+                    fromFile=use_file,
+                )
+
+                device_total_statistics = await myapi.get_device_pv_total_statistics(
+                    deviceSn=device_sn,
+                    fromFile=use_file,
+                )
+
+                CONSOLE.info(device_status | device_total_statistics)
+
+                if refresh == 0:
+                    break;
+
+    except (ClientError, errors.AnkerSolixError) as err:
+        CONSOLE.error("%s: %s", type(err), err)
+        CONSOLE.info("Api Requests: %s", myapi.request_count)
+        CONSOLE.info(myapi.request_count.get_details(last_hour=True))
+        return False
+
+    return True
+
+# run async main
+if __name__ == "__main__":
+    try:
+        if not asyncio.run(main(), debug=False):
+            CONSOLE.warning("\nAborted!")
+    except KeyboardInterrupt:
+        CONSOLE.warning("\nAborted!")
+    except Exception as exception:
+        CONSOLE.exception("%s: %s", type(exception), exception)


### PR DESCRIPTION
This PR adds methods for some `charging_pv_svc` endpoints that provider information about individual devices (probably only inverters, but cannot verify that) without having to create a system / site in the Anker app.

This allows monitoring of a single MI80 inverter (current and total power production) without having a solarbank.

For easier testing, i also added a `MI80_Standalone` example export of my system with example data for the new endpoints and a `inverter_monitor` test script.

Fixes https://github.com/thomluther/anker-solix-api/issues/180