### PR TITLE
add missing CONSOLE declaration in the usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ import common
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 # _LOGGER.setLevel(logging.DEBUG)    # enable for detailed Api output
+CONSOLE: logging.Logger = common.CONSOLE
 
 
 def _out(jsondata):


### PR DESCRIPTION
As described in #199 the usage example in README.md was missing the declaration for `CONSOLE`.
This fixes the program from crashing

closes #199 