### PR TITLE
Fix circular import issue with type annotations

### DIFF
--- a/api/energy.py
+++ b/api/energy.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 async def energy_daily(  # noqa: C901
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     startDay: datetime = datetime.today(),
@@ -540,7 +540,7 @@ async def energy_daily(  # noqa: C901
 
 
 async def energy_analysis(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     rangeType: str | None = None,
@@ -597,7 +597,7 @@ async def energy_analysis(
 
 
 async def home_load_chart(
-    self: AnkerSolixApi, siteId: str, deviceSn: str | None = None
+    self: "AnkerSolixApi", siteId: str, deviceSn: str | None = None
 ) -> dict:
     """Get home load chart data.
 
@@ -614,7 +614,7 @@ async def home_load_chart(
 
 
 async def refresh_pv_forecast(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     fromFile: bool = False,
 ) -> None:
@@ -912,7 +912,7 @@ async def refresh_pv_forecast(
 
 
 async def device_pv_energy_daily(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     startDay: datetime = datetime.today(),
     numDays: int = 1,
@@ -971,7 +971,7 @@ async def device_pv_energy_daily(
 
 
 async def get_device_pv_statistics(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     rangeType: str | None = None,
     startDay: datetime | None = None,
@@ -1028,7 +1028,7 @@ async def get_device_pv_statistics(
 
 
 async def get_device_charge_order_stats(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     rangeType: str | None = None,
     startDay: datetime | None = None,

--- a/api/mqtt_c1000x.py
+++ b/api/mqtt_c1000x.py
@@ -32,7 +32,7 @@ def validate_command_value(command_id: str, value: Any) -> bool:
 
 
 async def _send_c1000x_mqtt_command(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     device_sn: str,
     command: str,
     parameters: dict,
@@ -92,7 +92,7 @@ async def _send_c1000x_mqtt_command(
 
 
 async def set_c1000x_ac_output(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     enabled: bool,
     toFile: bool = False,
@@ -143,7 +143,7 @@ async def set_c1000x_ac_output(
 
 
 async def set_c1000x_dc_output(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     enabled: bool,
     toFile: bool = False,
@@ -194,7 +194,7 @@ async def set_c1000x_dc_output(
 
 
 async def set_c1000x_display(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     enabled: bool,
     toFile: bool = False,
@@ -244,7 +244,7 @@ async def set_c1000x_display(
 
 
 async def set_c1000x_backup_charge(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     enabled: bool,
     toFile: bool = False,
@@ -294,7 +294,7 @@ async def set_c1000x_backup_charge(
 
 
 async def set_c1000x_temp_unit(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     fahrenheit: bool,
     toFile: bool = False,
@@ -344,7 +344,7 @@ async def set_c1000x_temp_unit(
 
 
 async def set_c1000x_display_mode(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     mode: int | str,
     toFile: bool = False,
@@ -404,7 +404,7 @@ async def set_c1000x_display_mode(
 
 
 async def set_c1000x_light_mode(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     mode: int | str,
     toFile: bool = False,
@@ -464,7 +464,7 @@ async def set_c1000x_light_mode(
 
 
 async def set_c1000x_dc_output_mode(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     mode: int | str,
     toFile: bool = False,
@@ -524,7 +524,7 @@ async def set_c1000x_dc_output_mode(
 
 
 async def set_c1000x_ac_output_mode(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     mode: int | str,
     toFile: bool = False,
@@ -584,7 +584,7 @@ async def set_c1000x_ac_output_mode(
 
 
 async def get_c1000x_status(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     deviceSn: str,
     fromFile: bool = False,
 ) -> dict:

--- a/api/schedule.py
+++ b/api/schedule.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 async def get_device_load(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     fromFile: bool = False,
@@ -102,7 +102,7 @@ async def get_device_load(
 
 
 async def set_device_load(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     loadData: dict,
@@ -170,7 +170,7 @@ async def set_device_load(
 
 
 async def get_device_parm(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     paramType: str = SolixParmType.SOLARBANK_SCHEDULE.value,
     deviceSn: str | None = None,
@@ -333,7 +333,7 @@ async def get_device_parm(
 
 
 async def set_device_parm(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     paramData: dict,
     paramType: str = SolixParmType.SOLARBANK_SCHEDULE.value,
@@ -488,7 +488,7 @@ async def set_device_parm(
 
 
 async def set_home_load(  # noqa: C901
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     all_day: bool = False,
@@ -1368,7 +1368,7 @@ async def set_home_load(  # noqa: C901
 
 
 async def set_sb2_home_load(  # noqa: C901
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     preset: int | None = None,
@@ -2019,7 +2019,7 @@ async def set_sb2_home_load(  # noqa: C901
 
 
 async def set_sb2_ac_charge(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     backup_start: datetime | None = None,
@@ -2172,7 +2172,7 @@ async def set_sb2_ac_charge(
 
 
 async def set_sb2_use_time(  # noqa: C901
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     siteId: str,
     deviceSn: str,
     start_month: int | str | None = None,  # 1-12

--- a/api/vehicle.py
+++ b/api/vehicle.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 async def get_vehicle_list(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     fromFile: bool = False,
 ) -> dict:
     """Get the vehicle list defined for the user.
@@ -62,7 +62,7 @@ async def get_vehicle_list(
 
 
 async def get_vehicle_details(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     vehicleId: str,
     fromFile: bool = False,
 ) -> dict:
@@ -120,7 +120,7 @@ async def get_vehicle_details(
 
 
 async def get_brand_list(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     fromFile: bool = False,
 ) -> dict:
     """Get the vehicle brand list.
@@ -148,7 +148,7 @@ async def get_brand_list(
 
 
 async def get_brand_models(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     brand: str,
     fromFile: bool = False,
 ) -> dict:
@@ -182,7 +182,7 @@ async def get_brand_models(
 
 
 async def get_model_years(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     brand: str,
     model: str,
     fromFile: bool = False,
@@ -219,7 +219,7 @@ async def get_model_years(
 
 
 async def get_model_year_attributes(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     brand: str,
     model: str,
     year: str | int,
@@ -261,7 +261,7 @@ async def get_model_year_attributes(
 
 
 async def update_vehicle_options(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     vehicle: SolixVehicle | str | dict | None = None,
     cacheChain: bool = True,
     fromFile: bool = False,
@@ -326,7 +326,7 @@ async def update_vehicle_options(
 
 
 def get_vehicle_options(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     vehicle: SolixVehicle | str | dict | None = None,
     extendAttributes: bool = False,
 ) -> list:
@@ -400,7 +400,7 @@ def get_vehicle_options(
 
 
 async def get_vehicle_attributes(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     vehicle: SolixVehicle | str | dict | None = None,
     fromFile: bool = False,
 ) -> SolixVehicle | None:
@@ -458,7 +458,7 @@ async def get_vehicle_attributes(
 
 
 async def create_vehicle(
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     name: str,
     vehicle: SolixVehicle | str | dict | None,
     toFile: bool = False,
@@ -598,7 +598,7 @@ async def create_vehicle(
 
 
 async def manage_vehicle(  # noqa: C901
-    self: AnkerSolixApi,
+    self: "AnkerSolixApi",
     vehicleId: str,
     action: str,
     vehicle: SolixVehicle | str | dict | None = None,


### PR DESCRIPTION
## Summary
Quote AnkerSolixApi type annotations to resolve NameError during import.

## Changes
- Changes bare `self: AnkerSolixApi` to `self: "AnkerSolixApi"` across API modules
- Fixes circular import issues in energy.py, mqtt_c1000x.py, schedule.py, and vehicle.py

## Test plan
- [x] Verify test_c1000x_mqtt_controls.py runs without import errors
- [x] Confirm type checking still works with quoted annotations