### PR TITLE
Fix C1000X AC/DC output mode validation

### DIFF
--- a/api/mqtt_c1000x.py
+++ b/api/mqtt_c1000x.py
@@ -56,8 +56,8 @@ class SolixMqttDeviceC1000x(SolixMqttDevice):
             "temp_unit_control": lambda v: v in [0, 1],
             "display_mode_select": lambda v: v in [0, 1, 2, 3],
             "light_mode_select": lambda v: v in [0, 1, 2, 3, 4],
-            "dc_output_mode_select": lambda v: v in [1, 2],
-            "ac_output_mode_select": lambda v: v in [1, 2],
+            "dc_output_mode_select": lambda v: v in [0, 1],  # 0=Smart, 1=Normal
+            "ac_output_mode_select": lambda v: v in [0, 1],  # 0=Smart, 1=Normal
             "device_timeout_minutes": lambda v: 30 <= v <= 1440,
             "max_load": lambda v: 100 <= v <= 2000,
             "ac_charge_limit": lambda v: 100 <= v <= 800,
@@ -103,7 +103,7 @@ class SolixMqttDeviceC1000x(SolixMqttDevice):
             )
             return False
         # Convert string mode to int
-        mode_map = {"normal": 1, "smart": 2}
+        mode_map = {"normal": 1, "smart": 0}
         original_mode = mode
         if isinstance(mode, str):
             if (mode := mode_map.get(mode.lower())) is None:
@@ -180,7 +180,7 @@ class SolixMqttDeviceC1000x(SolixMqttDevice):
             )
             return False
         # Convert string mode to int
-        mode_map = {"normal": 1, "smart": 2}
+        mode_map = {"normal": 1, "smart": 0}
         original_mode = mode
         if isinstance(mode, str):
             if (mode := mode_map.get(mode.lower())) is None:


### PR DESCRIPTION
## Summary

This PR fixes a validation bug in C1000X AC/DC output mode controls where validation rules didn't match the actual MQTT command generation.

## Problem

- **Validation expected**: `[1,2]` with string mapping `{'smart': 2, 'normal': 1}`
- **MQTT commands use**: `[0,1]` with pattern `if mode==1: Normal else: Smart`
- **Result**: `mode='smart'` (→2) would pass validation but generate wrong command

## Solution

- Changed validation to `[0,1]` (0=Smart, 1=Normal)  
- Fixed string mapping to `{'smart': 0, 'normal': 1}`

## Validation

Tested against real C1000X device:
- `mode=1`: `ff09170003000f0077a10122a2020101` (Normal) ✅
- `mode=0`: `ff09170003000f0077a10122a2020100` (Smart) ✅  
- `mode=2`: `ff09170003000f0077a10122a2020100` (Smart - wrong input)

## Files Changed

- `api/mqtt_c1000x.py`: Fixed validation rules and string mapping

## Notes

- F3800 has the same validation pattern but is unchanged since F3800 commands haven't been validated against real hardware
- This only affects C1000X devices (A1761)