### PR TITLE
Fix "SyntaxError: multiple exception types must be parenthesized"

### DIFF
--- a/api/mqtt_device.py
+++ b/api/mqtt_device.py
@@ -188,7 +188,7 @@ class SolixMqttDevice:
                         # check if control is a single number control
                         control["is_number"] = bool(required_number)
                         self.controls[cmd] = control
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         self._logger.error(
                             "MQTT device %s (%s) control setup error - Command '%s' has invalid description for parameter '%s': %s",
                             self.sn,

--- a/monitor.py
+++ b/monitor.py
@@ -319,7 +319,7 @@ class AnkerSolixApiMonitor:
             )
             await self.input_task
             control = self.input_task.result()
-        except asyncio.CancelledError, KeyboardInterrupt:
+        except (asyncio.CancelledError, KeyboardInterrupt):
             # Handle gracefully
             CONSOLE.warning(f"\n{Color.RED}[Input Cancelled - Hit Enter]{Color.OFF}")
         finally:

--- a/mqtt_monitor.py
+++ b/mqtt_monitor.py
@@ -561,7 +561,7 @@ class AnkerSolixMqttMonitor:
                                     f"{Color.RED}\nRuntime exceeded, stopping monitor...{Color.OFF}"
                                 )
                                 break
-                        except asyncio.CancelledError, KeyboardInterrupt:
+                        except (asyncio.CancelledError, KeyboardInterrupt):
                             if self.input_task:
                                 CONSOLE.warning(
                                     f"\n{Color.RED}[Input Cancelled, hit ENTER]{Color.OFF}"
@@ -574,7 +574,7 @@ class AnkerSolixMqttMonitor:
                                 self.pause_output = False
                                 continue
                             raise
-                except asyncio.CancelledError, KeyboardInterrupt:
+                except (asyncio.CancelledError, KeyboardInterrupt):
                     if self.input_task:
                         CONSOLE.warning(
                             f"\n{Color.RED}[Input Cancelled, hit ENTER]{Color.OFF}"


### PR DESCRIPTION
I get this error when running mqtt_monitor.py
```
C:\anker-solix-api>poetry run python ./mqtt_monitor.py
  File "C:\anker-solix-api\mqtt_monitor.py", line 564
    except asyncio.CancelledError, KeyboardInterrupt:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```
I fixed that, then more of the same error showed up
```
C:\anker-solix-api>poetry run python ./mqtt_monitor.py
Traceback (most recent call last):
  File "C:\anker-solix-api\mqtt_monitor.py", line 32, in <module>
    from api.mqtt_factory import SolixMqttDeviceFactory  # pylint: disable=no-name-in-module
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\anker-solix-api\api\mqtt_factory.py", line 8, in <module>
    from .mqtt_charger import MODELS as CHARGER_MODELS, SolixMqttDeviceCharger
  File "C:\anker-solix-api\api\mqtt_charger.py", line 10, in <module>
    from .mqtt_device import SolixMqttDevice
  File "C:\anker-solix-api\api\mqtt_device.py", line 191
    except ValueError, TypeError:
           ^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```
After fixing those by adding parentheses, in total of 4 lines across 3 files, the tool works as normal.
