### PR TITLE
Add A17E1 (Anker SOLIX E10) MQTT field mapping for 0405 message type

### DIFF
--- a/api/mqttmap.py
+++ b/api/mqttmap.py
@@ -2835,6 +2835,29 @@ SOLIXMQTTMAP: Final[dict] = {
         # Interval: ~3-5 seconds, but only with realtime trigger
         "040a": _A17C1_040a,
     },
+    # Anker SOLIX E10
+    "A17E1": {
+        "0057": CMD_REALTIME_TRIGGER,
+        "0405": {
+            # E10 param_info - validated 2026-03-14 via controlled PV on/off tests
+            # charge_status: 0=idle, 1=discharging, 2=charging
+            # tou_period: 1=peak, 2=mid-peak, 3=off-peak, 4=super-off-peak
+            TOPIC: "param_info",
+            "a2": {NAME: "device_sn"},
+            "a3": {NAME: "battery_soc"},
+            "a4": {NAME: "charge_status"},
+            "a5": {NAME: "battery_temperature", SIGNED: True},
+            "a6": {NAME: "battery_soh?"},
+            "ab": {NAME: "pv_1_power"},
+            "ac": {NAME: "battery_power"},
+            "ad": {NAME: "inverter_ac_output?"},
+            "ae": {NAME: "inverter_dc_load?"},
+            "c3": {NAME: "tou_period?"},
+            "c4": {NAME: "grid_power"},
+            "c5": {NAME: "home_load_power"},
+            "c6": {NAME: "photovoltaic_power"},
+        },
+    },
     # Solarbank 2 E1600 AC
     "A17C2": {
         "0050": CMD_TEMP_UNIT,  # Temperature unit switch: Celsius (0) or Fahrenheit (1)


### PR DESCRIPTION
Validated 2026-03-14 via controlled PV on/off tests across 3 operating modes:
- Solar charging + home load (daytime)
- Grid only, PV switch off (controlled test)
- Battery discharging, ToU peak (nighttime)

Energy balance verified for 3 modes.
References #274
(Edited to keep issue open)

Adds initial MQTT field mapping for the Anker SOLIX E10 (model A17E1) to SOLIXMQTTMAP.

### Fields mapped (0405 / param_info topic)
- `battery_soc`, `charge_status`, `battery_temperature`
- `pv_1_power`, `photovoltaic_power` (total)
- `battery_power` (positive=charging, negative=discharging)
- `inverter_ac_output?`, `inverter_dc_load?`
- `grid_power`, `home_load_power`
- `tou_period?`, `battery_soh?`

### Still needs validation / identification

- `a6` (`battery_soh?`) — mirrors `a3` (battery_soc) exactly across all tests. 
  Hypothesis: may represent SOC of battery unit 1 only, with `a3` being combined/average SOC. 
  Requires de-stacking units to test individually — units must be fully charged to 100% 
  to re-balance before re-stacking, and wall bracket must be removed. Not currently feasible.

- Individual expansion battery identification — `b0`-`b4` fields show small consistent 
  float values (17-43W range) across all modes. Possibly per-battery or per-module data. 
  With 2x batteries installed, individual unit SOC/power fields are likely present but 
  unidentified. Other Anker devices (SB2) expose per-expansion fields separately.

- `pv_2_power` field — second solar circuit unused in test system. Candidates: `af`, `bb`, 
  `bc`, or `c7` (all consistently 0W throughout all tests). Requires second solar input 
  to validate.

- `tou_period?` (`c3`) — values 1=peak and 3=off-peak confirmed. Values 2=mid-peak and 
  4=super-off-peak not yet observed but assumed by ToU schedule structure (4 tiers).

- Total solar energy generated — app shows daily kWh (15.7kWh observed). Likely in `b1` 
  or similar field with a small factor (e.g. 0.0001) similar to `pv_yield` on SB2 devices. 
  `b0`-`b4` fields not yet decoded with factor interpretation applied.

- `040a` message type — not yet decoded, frequent ~100 byte updates.

- `0408` message type — fires only on first setting change per session (~431 bytes). 
  Possibly session initialization or full config sync.

- Individual power setting extraction (charge limits, discharge limits, schedule slots) — 
  not yet mapped. Likely in `0408` or `0507` message types.

- PowerWall expansion — not present in test system. Likely introduces its own device ID 
  with per-circuit energy monitoring (up to 3 inverters, 15 batteries, 28kW solar).


