### PR TITLE
Feature/a17e1 mqtt mapping v2

### DIFF
--- a/api/mqttmap.py
+++ b/api/mqttmap.py
@@ -3172,7 +3172,7 @@ SOLIXMQTTMAP: Final[dict] = {
             "a3": {NAME: "battery_soc"},
             "a4": {
                 NAME: "charging_status"
-            },  # 0=idle, 1=discharging, 2=charging
+            },  # charging_status: 0=idle, 1=discharging, 2=charging
             "a5": {NAME: "temperature", SIGNED: True},
             "a6": {NAME: "battery_soc?"},
             "a7": {NAME: "sw_version?", "values": 4},
@@ -3192,23 +3192,24 @@ SOLIXMQTTMAP: Final[dict] = {
             "c0": {NAME: "unknown_timestamp_0405_c0?"},
             "c3": {
                 NAME: "use_time_band?"
-            },  # 1=peak, 2=mid-peak, 3=off-peak, 4=super-off-peak (2,4 not yet observed)
+            },  # use_time_band: 1=peak, 2=mid-peak, 3=off-peak, 4=super-off-peak
             "c4": {NAME: "grid_power"},  # signed?
             "c5": {NAME: "home_demand"},
             "c6": {NAME: "pv_1_power?"},
             "c7": {NAME: "pv_2_power?"},
-            "af": {NAME: "ac_input_power?"},  # generator/AC input power to home
+            "af": {NAME: "generator_to_home_power?"},  # generator AC input power to home
             "ba": {
                 BYTES: {
-                    "02": [
-                        {NAME: "storm_guard_switch", MASK: 0x01},  # 0=off, 1=on
-                    ],
+                    "02": {
+                        NAME: "storm_guard_switch",
+                        TYPE: DeviceHexDataTypes.ui.value,
+                    },  # 0=off, 1=on
                 }
             },
-            "c2": {NAME: "total_ac_input_power?"},  # total generator output W
+            "c2": {NAME: "generator_output_power_total?"},  # total generator AC output W
             "cb": {NAME: "expansion_packs?"},  # number of expansion batteries
-            "d5": {NAME: "generator_to_battery_power?"},  # generator charging battery W
-            "dc": {NAME: "backup_mode_status?"},  # 0=grid-connected, 2=off-grid/backup
+            "d5": {NAME: "generator_to_battery_power?"},  # generator AC charging battery W
+            "dc": {NAME: "grid_status"},  # 0=grid-connected, 2=off-grid/backup
             "fe": {NAME: "msg_timestamp"},
         },
         "0408": {


### PR DESCRIPTION
Validated 2026-03-15 via controlled testing:

0405 additions:
- af: ac_to_home_power? (AC/generator input power to home)
- ba: storm_guard_switch bitmask (bit 0 of byte 2, 0=off, 1=on)
- c2: ac_input_power_total? (total AC/generator output W)
- d5: ac_to_battery_power? (AC/generator charging battery W)
- dc: backup_mode_status? (0=grid-connected, 2=off-grid/backup)

Comments updated:
- usage_mode? confirmed: 2=self-consume, 4=manual-backup, 5=ToU, 8=backup/emergency
- use_time_band? confirmed: 1=peak, 3=off-peak (2,4 not yet observed, inferred by pattern)
- charging_status comment cleaned up

Energy balance verified for generator/AC input mode:
ac_input(8490W) = ac_to_battery(7640W) + home(850W) = 8490W

References #274"



I did my best to keep it from renaming anything you've already named.
-  with how the inverter was behaving with over/under volts on my generator i'll be lowering it's peak output to 7600 and will make another attempt this week to do a verification of the AC generator input values. - i do expect there's DC generator values i wont be able to discover.