### PR TITLE
A17X8: decode plug schedule fields, extend timer with pause/resume

### DIFF
--- a/api/mqttcmdmap.py
+++ b/api/mqttcmdmap.py
@@ -884,29 +884,33 @@ CMD_PLUG_SCHEDULE = CMD_COMMON | {
     # Command: Smartplug schedule
     COMMAND_NAME: SolixMqttCommands.plug_schedule,
     "a2": {
-        NAME: "set_plug_schedule_a2?",  # 1 - unknown
+        NAME: "set_plug_schedule_action",  # 0=delete, 1=create, 2=modify
         TYPE: DeviceHexDataTypes.ui.value,
         VALUE_DEFAULT: 1,
     },
     "a3": {
-        NAME: "set_plug_schedule_order?",  # 1 - x
+        NAME: "set_plug_schedule_slot",  # schedule slot index, 1-x
         TYPE: DeviceHexDataTypes.ui.value,
         VALUE_MIN: 1,
         VALUE_MAX: 10,
     },
     "a4": {
-        NAME: "set_plug_schedule_a4?",  # 1 - unknown
+        NAME: "set_plug_schedule_enabled",  # 0=disabled, 1=enabled
         TYPE: DeviceHexDataTypes.ui.value,
         VALUE_DEFAULT: 1,
     },
     "a5": TIME_SILE
     | {
-        NAME: "set_plug_schedule_time",  # min;hour
+        NAME: "set_plug_schedule_time",  # min;hour as byte pair
     },
     "a6": {
         NAME: "set_plug_schedule_switch",  # Off (0), On (1)
         TYPE: DeviceHexDataTypes.ui.value,
         VALUE_OPTIONS: {"off": 0, "on": 1},
+    },
+    "a7": {
+        NAME: "set_plug_schedule_weekdays",  # day numbers: 1=Mon..7=Sun, variable length (1 byte per day)
+        TYPE: DeviceHexDataTypes.var.value,
     },
 }
 
@@ -914,9 +918,9 @@ CMD_PLUG_DELAYED_TOGGLE = CMD_COMMON | {
     # Command: Smartplug delayed toggle
     COMMAND_NAME: SolixMqttCommands.plug_delayed_toggle,
     "a2": {
-        NAME: "set_toggle_to_switch?",  # Off (0), On (1)
+        NAME: "set_toggle_to_switch?",  # Off (0), On (1), Pause (2)?, Resume (3)? — values 2+3 observed on FW 0.0.2.7
         TYPE: DeviceHexDataTypes.ui.value,
-        VALUE_OPTIONS: {"off": 0, "on": 1},
+        VALUE_OPTIONS: {"off": 0, "on": 1, "pause": 2, "resume": 3},
     },
     "a3": {
         # NAME: "set_toggle_to_delay?",  # 3 bytes: Seconds:Minutes:Hours


### PR DESCRIPTION
Verified on A17X8 SmartPlug (FW 0.0.2.7) via mqtt_monitor, 2026-03-25, 4 sessions.

## Schedule (007c)

Decoded fields:
- a2: 0=delete, 1=create, 2=modify (was `set_plug_schedule_a2?`)
- a4: 0=disabled, 1=enabled (was `set_plug_schedule_a4?`)
- a6: 0=OFF confirmed, 1=ON confirmed (separate sessions)
- a7: new field — weekday selection as day numbers (1=Mon..7=Sun), variable length

Observed a7 values across targeted single-day tests:
- `0x01` (1 byte) = Monday only
- `0x02` (1 byte) = Tuesday only
- `0x07` (1 byte) = Sunday only
- `0x01:0x07` (2 bytes) = Monday + Sunday

## Timer (007e)

Extended a2 values beyond existing off(0)/on(1):
- a2=2: pause — status byte in ad field switches from 3 to 2, elapsed time freezes
- a2=3: resume — status byte switches from 2 to 3, elapsed continues counting

Verified in controlled test: start(a2=1) -> elapsed counts 1,4,7,11s -> pause(a2=2) -> elapsed freezes at 11s (6 consecutive status messages) -> resume(a2=3) -> elapsed continues 12,13,15,18,21,23s -> cancel(a2=0) -> ad field clears to zeros.

Values 2+3 may be firmware-dependent (tested on FW 0.0.2.7), marked with ? in comment.

Dumps available on request.