### PR TITLE
Add mapping for C200 DC

### DIFF
--- a/api/mqttmap.py
+++ b/api/mqttmap.py
@@ -127,6 +127,48 @@ _PPS_VERSIONS_0830 = {
     },
 }
 
+_A1725_0405 = {
+    # C200 DC param info (A1725/A1727)
+    TOPIC: "param_info",
+    "a1": {NAME: "device_pn"},  # Device PN identifier
+    "a3": {NAME: "remaining_time_hours", FACTOR: 0.1, SIGNED: False},  # Remaining runtime
+    "a4": {NAME: "usbc_1_power"},  # USB-C top output power
+    "a5": {NAME: "usbc_2_power"},  # USB-C middle output power
+    "a6": {NAME: "usbc_3_power"},  # USB-C bottom input/output power
+    "a8": {NAME: "usba_1_power"},  # USB-A top output power
+    "a9": {NAME: "usba_2_power"},  # USB-A bottom output power
+    "ab": {NAME: "photovoltaic_power"},  # Solar input power (W)
+    "ac": {NAME: "dc_input_power_total"},  # Total input power (solar + C3 input when charging)
+    "ad": {NAME: "dc_output_power_total"},  # Total USB output power
+    "b5": {NAME: "temperature", SIGNED: True},  # In Celsius
+    "b6": {NAME: "charging_status"},  # Power state: 0=idle, 1=discharge, 2=charge
+    "b7": {NAME: "battery_soc"},  # Battery state of charge (%)
+    "b9": {NAME: "usbc_1_status"},  # USB-C1 top status: Inactive (0), Discharging (1)
+    "ba": {NAME: "usbc_2_status"},  # USB-C2 middle status: Inactive (0), Discharging (1)
+    "bb": {NAME: "usbc_3_status"},  # USB-C3 bottom status: Inactive (0), Discharging (1), Charging (2)
+    "bd": {NAME: "usba_1_status"},  # USB-A1 top status: Inactive (0), Discharging (1)
+    "be": {NAME: "usba_2_status"},  # USB-A2 bottom status: Inactive (0), Discharging (1)
+    "c3": {NAME: "device_sn"},
+    "c4": {
+        NAME: "device_timeout_minutes"
+    },  # Device timeout: never, 30, 60, 120, 240, 360, 720, 1440 minutes
+    "c5": {
+        NAME: "display_timeout_seconds"
+    },  # Display timeout: 20, 30, 60, 300, 1800 seconds
+    "c7": {NAME: "display_mode"},  # Brightness: Low (1), Medium (2), High (3)
+    "c9": {NAME: "temp_unit_fahrenheit"},  # Temperature unit: Celsius (0), Fahrenheit (1)
+    "ca": {NAME: "display_switch"},  # Off (0) or On (1)
+    "cd": {NAME: "charging_status"},  # Inactive (0), Solar (1)
+    "fe": {NAME: "msg_timestamp"},  # Message timestamp
+}
+
+_A1725_0401 = {
+    # C200 DC param info (A1725/A1727) - settings
+    TOPIC: "param_info",
+    "a1": {NAME: "device_pn"},  # Device PN identifier
+    "a4": {NAME: "display_switch"},  # Off (0) or On (1)
+}
+
 _A1722_0405 = {
     # C300 AC param info
     TOPIC: "param_info",
@@ -3745,6 +3787,25 @@ _PP_JSON = {
 
 # Following is the consolidated mapping for all device types and messages
 SOLIXMQTTMAP: Final[dict] = {
+    # PPS C200 (A1725/A1727)
+    "A1725": {
+        "0045": CMD_DEVICE_TIMEOUT_MIN,  # Device timeout: 0 (Never), 30, 60, 120, 240, 360, 720, 1440 minutes
+        "0046": CMD_DISPLAY_TIMEOUT_SEC,  # Options in seconds: 20, 30, 60, 300, 1800 seconds
+        "004c": CMD_DISPLAY_MODE,  # Display brightness: Low (1), Medium (2), High (3)
+        "0052": CMD_DISPLAY_SWITCH,  # Display switch: Disabled (0) or Enabled (1)
+        "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        "0401": _A1725_0401,  # Interval: Irregular, triggered on app/device actions
+        "0405": _A1725_0405,  # Interval: ~3-5 seconds, but only with realtime trigger
+    },
+    "A1727": {
+        "0045": CMD_DEVICE_TIMEOUT_MIN,  # Device timeout: 0 (Never), 30, 60, 120, 240, 360, 720, 1440 minutes
+        "0046": CMD_DISPLAY_TIMEOUT_SEC,  # Options in seconds: 20, 30, 60, 300, 1800 seconds
+        "004c": CMD_DISPLAY_MODE,  # Display brightness: Low (1), Medium (2), High (3)
+        "0052": CMD_DISPLAY_SWITCH,  # Display switch: Disabled (0) or Enabled (1)
+        "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        "0401": _A1725_0401,  # Interval: Irregular, triggered on app/device actions
+        "0405": _A1725_0405,  # Interval: ~3-5 seconds, but only with realtime trigger
+    },
     # PPS C300 AC
     "A1722": {
         "0044": CMD_AC_CHARGE_LIMIT  # AC Recharge Limit: 100, 200, 300, 330 W


### PR DESCRIPTION
Fully mapped everything accessible via the Anker app.
Please note this covers both the C200X (A1725) and C200 (A1727), though I only have the A1727.  I can update it to not cover the A1725 if you'd like, since I cannot test it.

System export with MQTT messages: [Jessica Morgan_2026-04-20_2000.zip](https://github.com/user-attachments/files/26914539/Jessica.Morgan_2026-04-20_2000.zip)
During export of above I flipped every setting I could on my C200, Everfrost 2 40L, and 240w charging station, in case that's helpful at all.  I'll try mapping the cooler next.