### PR TITLE
Add A1729 C200X DC MQTT telemetry support

### DIFF
--- a/api/mqttmap.py
+++ b/api/mqttmap.py
@@ -297,6 +297,8 @@ _A1729_0405 = _A1725_0405 | {
     # A1729 matches the C200 DC telemetry layout, but cd is only the solar input
     # status. Keep b6 as the overall charging_status because C3 charging reports
     # b6=2 while cd remains 0.
+    "af": {NAME: "battery_soc_ah", FACTOR: 0.001},  # Battery SOC (Ah)
+    "b8": {NAME: "battery_soh"},  # Battery health
     "cd": {NAME: "solar_input_status"},  # Inactive (0), Solar (1)
 }
 

--- a/api/mqttmap.py
+++ b/api/mqttmap.py
@@ -292,6 +292,14 @@ _A1728_0405 = {
     "fe": {NAME: "msg_timestamp"},  # Message timestamp
 }
 
+_A1729_0405 = _A1725_0405 | {
+    # C200X DC param info (A1729)
+    # A1729 matches the C200 DC telemetry layout, but cd is only the solar input
+    # status. Keep b6 as the overall charging_status because C3 charging reports
+    # b6=2 while cd remains 0.
+    "cd": {NAME: "solar_input_status"},  # Inactive (0), Solar (1)
+}
+
 _A1761_0405 = {
     # PPS C1000(X) parm info
     TOPIC: "param_info",
@@ -3992,6 +4000,18 @@ SOLIXMQTTMAP: Final[dict] = {
         "0401": _A1728_0401,  # Interval: Irregular, triggered on app/device actions, no fixed interval
         "0404": _A1728_0404,  # Interval: Irregular, triggered on app action, no fixed interval
         "0405": _A1728_0405,  # Interval: ~3-5 seconds, but only with realtime trigger
+        "0830": _PPS_VERSIONS_0830,  # Interval: Irregular, triggered on app actions, no fixed interval
+    },
+    # SOLIX C200X DC A1729
+    "A1729": {
+        "0045": CMD_DEVICE_TIMEOUT_MIN,  # Device timeout: 0 (Never), 30, 60, 120, 240, 360, 720, 1440 minutes
+        "0046": CMD_DISPLAY_TIMEOUT_SEC,  # Options in seconds: 20, 30, 60, 300, 1800 seconds
+        "004c": CMD_DISPLAY_MODE,  # Display brightness: Low (1), Medium (2), High (3)
+        "0050": CMD_TEMP_UNIT,  # Temperature unit switch: Celsius (0) or Fahrenheit (1)
+        "0052": CMD_DISPLAY_SWITCH,  # Display switch: Disabled (0) or Enabled (1)
+        "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        "0401": _A1725_0401,  # Interval: Irregular, triggered on app/device actions
+        "0405": _A1729_0405,  # Interval: ~3-5 seconds, but only with realtime trigger
         "0830": _PPS_VERSIONS_0830,  # Interval: Irregular, triggered on app actions, no fixed interval
     },
     # PPS C1000(X) + B1000 Extension


### PR DESCRIPTION
@thomluther
I recently tested the A1729 (SOLIX C200X DC) and found it was remarkably similar to the excellent work done by @JessMorgan with one small difference. 

The delta, as I understand it is `cd` is only the solar input status. Keep `b6` as the overall charging_status because `c3` charging reports `b6=2` while `cd` remains `0`. I also noted this in a code comment.

Thanks for all your work on this!

Here are some captures from both cases:

Solar Charging (95W):
```
------------------------- Pps / A1729 / 0405 / Header --------------------------
ff 09   : 2 Byte Anker Solix message marker (supposed 'ff 09')
03 01   : 2 Byte total message length (259) in Bytes (Little Endian format)
03 01 0f: 3 Byte fixed message pattern (supposed `03 00/01 0f` for send/receive)
04 05   : 2 Byte message type pattern (varies per device model and message type)
        : 1 Byte optional message increment (  0)
-> db <-: XOR Checksum Byte (last message byte), Crosscheck: 00 => OK
-- Fields --|- Value (Hex/Decode Options)---------------------------------------
Fld Len Type       uIntLe/var          sIntLe         floatLe      dblLe/4int
a1   01 --    34
└->   1 unk   b'4' --> device_pn
a2   05 03    00:00:00:00
└->   5 var               0;0               0           0.000         0;0;0;0
a3   03 02    01:00
└->   3 sile                1               1                             1;0 --> remaining_time_hours (factor 0.1) (signed False)
a4   03 02    00:00
└->   3 sile                0               0                             0;0 --> usbc_1_power
a5   03 02    00:00
└->   3 sile                0               0                             0;0 --> usbc_2_power
a6   03 02    00:00
└->   3 sile                0               0                             0;0 --> usbc_3_power
a7   03 02    00:00
└->   3 sile                0               0                             0;0
a8   03 02    00:00
└->   3 sile                0               0                             0;0 --> usba_1_power
a9   03 02    00:00
└->   3 sile                0               0                             0;0 --> usba_2_power
aa   03 02    00:00
└->   3 sile                0               0                             0;0
ab   03 02    5f:00
└->   3 sile               95              95                            95;0 --> photovoltaic_power
ac   03 02    5f:00
└->   3 sile               95              95                            95;0 --> dc_input_power_total
ad   03 02    00:00
└->   3 sile                0               0                             0;0 --> dc_output_power_total
ae   03 02    00:00
└->   3 sile                0               0                             0;0
af   03 02    6d:39
└->   3 sile            14701           14701                          109;57
b0   03 02    79:00
└->   3 sile              121             121                           121;0
b1   03 02    65:00
└->   3 sile              101             101                           101;0
b2   03 02    e2:00
└->   3 sile              226             226                           226;0
b3   03 02    79:00
└->   3 sile              121             121                           121;0
b4   03 02    79:00
└->   3 sile              121             121                           121;0
b5   02 01    21
└->   2 ui                 33              33 --> temperature (signed True)
b6   02 01    02
└->   2 ui                  2               2 --> charging_status
b7   02 01    63
└->   2 ui                 99              99 --> battery_soc
b8   02 01    64
└->   2 ui                100             100
b9   02 01    00
└->   2 ui                  0               0 --> usbc_1_status
ba   02 01    00
└->   2 ui                  0               0 --> usbc_2_status
bb   02 01    00
└->   2 ui                  0               0 --> usbc_3_status
bc   02 01    00
└->   2 ui                  0               0
bd   02 01    00
└->   2 ui                  0               0 --> usba_1_status
be   02 01    00
└->   2 ui                  0               0 --> usba_2_status
bf   02 01    00
└->   2 ui                  0               0
c0   02 01    00
└->   2 ui                  0               0
c1   02 01    00
└->   2 ui                  0               0
c2   02 01    00
└->   2 ui                  0               0
c3   11 00    41:5a:56:5a:47:38:30:45:34:35:33:30:30:31:39:30
└->  17 str   b'AZVZG80E45300190' --> device_sn
c4   03 02    78:00
└->   3 sile              120             120                           120;0 --> device_timeout_minutes
c5   03 02    1e:00
└->   3 sile               30              30                            30;0 --> display_timeout_seconds
c6   03 02    00:00
└->   3 sile                0               0                             0;0
c7   02 01    02
└->   2 ui                  2               2 --> display_mode
c8   02 01    00
└->   2 ui                  0               0
c9   02 01    01
└->   2 ui                  1               1 --> temp_unit_fahrenheit
ca   02 01    00
└->   2 ui                  0               0 --> display_switch
cb   03 02    00:00
└->   3 sile                0               0                             0;0
cc   02 01    00
└->   2 ui                  0               0
cd   02 01    01
└->   2 ui                  1               1 --> solar_input_status
f8   15 04    00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
└->  21 bin   b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
fe   05 03    2b:e4:eb:69
└->   5 var       -7125;27115      1777067051 35646882547190913084424192.000  43;228;235;105 --> msg_timestamp (2026-04-24 16:44:11)
--------------------------------------------------------------------------------
```

USB-C3 Charging (89W):
```
------------------------- Pps / A1729 / 0405 / Header --------------------------
ff 09   : 2 Byte Anker Solix message marker (supposed 'ff 09')
03 01   : 2 Byte total message length (259) in Bytes (Little Endian format)
03 01 0f: 3 Byte fixed message pattern (supposed `03 00/01 0f` for send/receive)
04 05   : 2 Byte message type pattern (varies per device model and message type)
        : 1 Byte optional message increment (  0)
-> cd <-: XOR Checksum Byte (last message byte), Crosscheck: 00 => OK
-- Fields --|- Value (Hex/Decode Options)---------------------------------------
Fld Len Type       uIntLe/var          sIntLe         floatLe      dblLe/4int
a1   01 --    34
└->   1 unk   b'4' --> device_pn
a2   05 03    00:00:00:00
└->   5 var               0;0               0           0.000         0;0;0;0
a3   03 02    01:00
└->   3 sile                1               1                             1;0 --> remaining_time_hours (factor 0.1) (signed False)
a4   03 02    0d:00
└->   3 sile               13              13                            13;0 --> usbc_1_power
a5   03 02    05:00
└->   3 sile                5               5                             5;0 --> usbc_2_power
a6   03 02    59:00
└->   3 sile               89              89                            89;0 --> usbc_3_power
a7   03 02    00:00
└->   3 sile                0               0                             0;0
a8   03 02    02:00
└->   3 sile                2               2                             2;0 --> usba_1_power
a9   03 02    03:00
└->   3 sile                3               3                             3;0 --> usba_2_power
aa   03 02    00:00
└->   3 sile                0               0                             0;0
ab   03 02    00:00
└->   3 sile                0               0                             0;0 --> photovoltaic_power
ac   03 02    59:00
└->   3 sile               89              89                            89;0 --> dc_input_power_total
ad   03 02    17:00
└->   3 sile               23              23                            23;0 --> dc_output_power_total
ae   03 02    00:00
└->   3 sile                0               0                             0;0
af   03 02    d9:38
└->   3 sile            14553           14553                          217;56
b0   03 02    79:00
└->   3 sile              121             121                           121;0
b1   03 02    65:00
└->   3 sile              101             101                           101;0
b2   03 02    e2:00
└->   3 sile              226             226                           226;0
b3   03 02    79:00
└->   3 sile              121             121                           121;0
b4   03 02    79:00
└->   3 sile              121             121                           121;0
b5   02 01    21
└->   2 ui                 33              33 --> temperature (signed True)
b6   02 01    02
└->   2 ui                  2               2 --> charging_status
b7   02 01    62
└->   2 ui                 98              98 --> battery_soc
b8   02 01    64
└->   2 ui                100             100
b9   02 01    01
└->   2 ui                  1               1 --> usbc_1_status
ba   02 01    01
└->   2 ui                  1               1 --> usbc_2_status
bb   02 01    02
└->   2 ui                  2               2 --> usbc_3_status
bc   02 01    00
└->   2 ui                  0               0
bd   02 01    01
└->   2 ui                  1               1 --> usba_1_status
be   02 01    01
└->   2 ui                  1               1 --> usba_2_status
bf   02 01    00
└->   2 ui                  0               0
c0   02 01    00
└->   2 ui                  0               0
c1   02 01    00
└->   2 ui                  0               0
c2   02 01    00
└->   2 ui                  0               0
c3   11 00    41:5a:56:5a:47:38:30:45:34:35:33:30:30:31:39:30
└->  17 str   b'AZVZG80E45300190' --> device_sn
c4   03 02    78:00
└->   3 sile              120             120                           120;0 --> device_timeout_minutes
c5   03 02    1e:00
└->   3 sile               30              30                            30;0 --> display_timeout_seconds
c6   03 02    00:00
└->   3 sile                0               0                             0;0
c7   02 01    02
└->   2 ui                  2               2 --> display_mode
c8   02 01    00
└->   2 ui                  0               0
c9   02 01    01
└->   2 ui                  1               1 --> temp_unit_fahrenheit
ca   02 01    01
└->   2 ui                  1               1 --> display_switch
cb   03 02    00:00
└->   3 sile                0               0                             0;0
cc   02 01    00
└->   2 ui                  0               0
cd   02 01    00
└->   2 ui                  0               0 --> solar_input_status
f8   15 04    00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
└->  21 bin   b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
fe   05 03    96:e7:eb:69
└->   5 var       -6250;27115      1777067926 35648900159823975066632192.000 150;231;235;105 --> msg_timestamp (2026-04-24 16:58:46)
--------------------------------------------------------------------------------
```