### PR TITLE
Add A1781 SOLIX F2600 MQTT support (telemetry + controls)

### DIFF
--- a/api/mqtt_pps.py
+++ b/api/mqtt_pps.py
@@ -59,6 +59,7 @@ FEATURES = {
     SolixMqttCommands.dc_output_switch: MODELS,
     SolixMqttCommands.dc_12v_output_mode_select: MODELS,
     SolixMqttCommands.dc_output_timeout_seconds: MODELS,
+    SolixMqttCommands.energy_saving_mode: MODELS,
     SolixMqttCommands.display_switch: MODELS,
     SolixMqttCommands.display_mode_select: MODELS,
     SolixMqttCommands.display_timeout_seconds: MODELS,

--- a/api/mqttcmdmap.py
+++ b/api/mqttcmdmap.py
@@ -89,6 +89,7 @@ class SolixMqttCommands:
     dc_output_switch: str = "dc_output_switch"
     dc_12v_output_mode_select: str = "dc_12v_output_mode_select"
     dc_output_timeout_seconds: str = "dc_output_timeout_seconds"
+    energy_saving_mode: str = "energy_saving_mode"
     display_switch: str = "display_switch"
     display_mode_select: str = "display_mode_select"
     display_timeout_seconds: str = "display_timeout_seconds"
@@ -406,6 +407,17 @@ CMD_DC_OUTPUT_TIMEOUT_SEC = (
         },
     }
 )
+
+CMD_ENERGY_SAVING_MODE = CMD_COMMON | {
+    # Command: PPS energy/power saving mode setting
+    COMMAND_NAME: SolixMqttCommands.energy_saving_mode,
+    "a2": {
+        NAME: "set_energy_saving_mode",  # Disable (0) | Enable (1)
+        TYPE: DeviceHexDataTypes.ui.value,
+        STATE_NAME: "energy_saving_mode",
+        VALUE_OPTIONS: {"off": 0, "on": 1},
+    },
+}
 
 CMD_LIGHT_SWITCH = CMD_COMMON | {
     # Command: PPS LED light switch setting

--- a/api/mqttmap.py
+++ b/api/mqttmap.py
@@ -10,12 +10,14 @@ from .mqttcmdmap import (
     CMD_AC_FAST_CHARGE_SWITCH,
     CMD_AC_OUTPUT_MODE,
     CMD_AC_OUTPUT_SWITCH,
+    CMD_AC_OUTPUT_TIMEOUT_SEC,
     CMD_AC_PORT_SWITCH,
     CMD_BATTERY_CHARGE_LIMITS,
     CMD_COMMON_V2,
     CMD_DC_12V_OUTPUT_MODE,
     CMD_DC_OUTPUT_SWITCH,
     CMD_DC_OUTPUT_TIMEOUT_SEC,
+    CMD_ENERGY_SAVING_MODE,
     # CMD_DEVICE_MAX_LOAD,
     CMD_DEVICE_POWER_MODE,
     CMD_DEVICE_SWITCH,
@@ -956,6 +958,14 @@ _A1780_0408 = {
     "a6": {NAME: "discharged_energy?", FACTOR: 0.001},  # in kWh
     "a7": {NAME: "charged_energy?", FACTOR: 0.001},  # in kWh
     "ac": {NAME: "main_battery_soc"},  # in %
+}
+
+_A1781_0405 = _A1780_0405 | {
+    # F2600 param info (A1781)
+    # A1781 matches the F2000 telemetry layout, plus a2/a3 carry the
+    # active AC/DC auto-off countdowns (always-zero composite slots on F2000).
+    "a2": {NAME: "ac_output_timeout_seconds"},  # Active AC auto-off countdown in seconds
+    "a3": {NAME: "dc_output_timeout_seconds"},  # Active DC auto-off countdown in seconds
 }
 
 _A1782_0421 = {
@@ -4624,6 +4634,38 @@ SOLIXMQTTMAP: Final[dict] = {
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0405": _A1780_0405,
         # Interval: irregular, triggerd by wifi signal change?
+        "0407": _PPS_0407,
+        # Interval: ??
+        "0408": _A1780_0408,
+        # Interval: Irregular, triggered on app actions, no fixed interval
+        "0830": _PPS_VERSIONS_0830,
+    },
+    # PPS F2600
+    "A1781": {
+        "0042": CMD_AC_OUTPUT_TIMEOUT_SEC,  # AC output timeout: 0-86400 seconds, step 300
+        "0043": CMD_DC_OUTPUT_TIMEOUT_SEC,  # DC output timeout: 0-86400 seconds, step 300
+        "0044": CMD_AC_CHARGE_LIMIT  # in W; min: 100, max: 1440, step: 100
+        | {
+            "a2": {
+                **CMD_AC_CHARGE_LIMIT["a2"],
+                VALUE_MIN: 100,
+                VALUE_MAX: 1440,
+                VALUE_STEP: 100,
+            }
+        },
+        # 0045 omitted: F2600 reports d2=0 in telemetry but ignores writes
+        "0046": CMD_DISPLAY_TIMEOUT_SEC,  # Options in seconds: 20, 30, 60, 300, 1800 seconds
+        "004a": CMD_AC_OUTPUT_SWITCH,  # AC output switch: Disabled (0) or Enabled (1)
+        "004b": CMD_DC_OUTPUT_SWITCH,  # DC output switch: Disabled (0) or Enabled (1)
+        "004c": CMD_DISPLAY_MODE,  # Display brightness: Off (0), Low (1), Medium (2), High (3)
+        "004e": CMD_ENERGY_SAVING_MODE,  # Power saving mode: Off (0) or On (1)
+        "004f": CMD_LIGHT_MODE,  # LED mode: Off (0), Low (1), Medium (2), High (3), Blinking (4)
+        "0052": CMD_DISPLAY_SWITCH,  # Display switch: Disabled (0) or Enabled (1)
+        "0050": CMD_TEMP_UNIT,  # Temperature unit switch: Celsius (0) or Fahrenheit (1)
+        "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        # Interval: ~3-5 seconds, but only with realtime trigger
+        "0405": _A1781_0405,
+        # Interval: irregular, triggered by wifi signal change?
         "0407": _PPS_0407,
         # Interval: ??
         "0408": _A1780_0408,


### PR DESCRIPTION
Adds A1781 (SOLIX F2600) MQTT support — telemetry and controls. The F2600 uses the same 0405 packet type and TLV schema as the F2000, so the A1781 entry reuses _A1780_0405, _A1780_0408, _PPS_0407 and _PPS_VERSIONS_0830 by reference. A1781 was already known to apitypes.py and mqtt_pps.py; only the per-model packet decoder map was missing.

Extends the F2000 schema for the F2600 via a small _A1781_0405 overlay (same pattern as _A1729_0405 from #294): tags a2/a3 carry the active AC/DC auto-off countdowns on the F2600 — they're inert composite slots on the F2000.

Adds CMD_ENERGY_SAVING_MODE (cmd 0x004e, telemetry tag db) for the "Power Saving Mode" toggle in the Anker app, modeled on CMD_DC_OUTPUT_SWITCH. Wires 0x0042/0x0043 (AC/DC output timeout) and 0x004e into the A1781 command map alongside the inherited F2000 controls. 0x0045 (device_timeout_minutes) intentionally omitted - F2600 ignores writes and the app has no corresponding setting.

Verified on my own F2600 (firmware v3.4.6) by capturing the iOS app's commands with mqtt_monitor.py and confirming the matching state flips in subsequent 0405 frames. All controls also exercised end-to-end through ha-anker-solix standing in front of the unit. System export attached in a follow-up comment.

<img width="1019" height="1859" alt="image" src="https://github.com/user-attachments/assets/c7bc09a2-b116-4ea3-89a1-b7f8c2f275a3" />
