### PR TITLE
Add Power Panel manual backup (disaster preparedness) support

### DIFF
--- a/examples/PowerPanel_ManualBackup/charging_disaster_support_func_f6a1b2c3-d4e5-6789-abcd-ef0123456789.json
+++ b/examples/PowerPanel_ManualBackup/charging_disaster_support_func_f6a1b2c3-d4e5-6789-abcd-ef0123456789.json
@@ -1,0 +1,18 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "support_auto_disaster": true,
+    "support_country_code": [
+      {
+        "code": "US",
+        "google_code": "ChIJCzYy5IS16lQRQrfeQ5K5Oxw"
+      },
+      {
+        "code": "PR",
+        "google_code": "ChIJ-aeSGyaWAowRGpsEGCjsNvM"
+      }
+    ]
+  },
+  "trace_id": "0000000000000000000000000002sample"
+}

--- a/examples/PowerPanel_ManualBackup/charging_site_device_disaster_f6a1b2c3-d4e5-6789-abcd-ef0123456789.json
+++ b/examples/PowerPanel_ManualBackup/charging_site_device_disaster_f6a1b2c3-d4e5-6789-abcd-ef0123456789.json
@@ -1,0 +1,20 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "auto_disaster_switch": false,
+    "manual_disaster_switch": true,
+    "disaster_details": [
+      {
+        "uuid": "00000000-0000-0000-0000-000000000001",
+        "disaster_type": 1,
+        "event": "",
+        "start_time": 1780988280,
+        "end_time": 1780991880,
+        "charging_time": 36,
+        "event_key": ""
+      }
+    ]
+  },
+  "trace_id": "0000000000000000000000000000sample"
+}

--- a/examples/PowerPanel_ManualBackup/charging_site_device_disaster_status_f6a1b2c3-d4e5-6789-abcd-ef0123456789.json
+++ b/examples/PowerPanel_ManualBackup/charging_site_device_disaster_status_f6a1b2c3-d4e5-6789-abcd-ef0123456789.json
@@ -1,0 +1,18 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "auto_disaster_status": 2,
+    "manual_disaster_status": 1,
+    "current_disaster_detail": {
+      "uuid": "00000000-0000-0000-0000-000000000001",
+      "disaster_type": 1,
+      "event": "",
+      "start_time": 1780988280,
+      "end_time": 1780991880,
+      "charging_time": 36,
+      "event_key": ""
+    }
+  },
+  "trace_id": "0000000000000000000000000001sample"
+}

--- a/src/anker_solix_api/apitypes.py
+++ b/src/anker_solix_api/apitypes.py
@@ -220,9 +220,6 @@ API_CHARGING_ENDPOINTS: Final[dict] = {
     "get_site_device_disaster_status": "charging_disaster_prepared/get_site_device_disaster_status",  # {"identifier_id": siteId, "type": 2}
     "set_site_device_disaster": "charging_disaster_prepared/set_site_device_disaster",  # ON: switch True + manual_disaster_detail; OFF: switch False, omit detail
     "get_disaster_support_func": "charging_disaster_prepared/get_support_func",  # {"identifier_id": siteId, "type": 2}
-    "quit_disaster_prepare": "charging_disaster_prepared/quit_disaster_prepare",
-    "disaster_clear": "charging_disaster_prepared/clear",
-    "disaster_detail": "charging_disaster_prepared/disaster_detail",
 }
 
 """Following are the Anker Power/Solix Cloud API charging_hes_svc endpoints known so far. They are used for Home Energy Systems like X1."""
@@ -627,6 +624,9 @@ API_FILEPREFIXES: Final[dict] = {
     # charging_energy_service endpoint file prefixes
     "charging_get_error_info": "charging_error_info",
     "charging_get_system_running_info": "charging_system_running_info",
+    "charging_get_site_device_disaster": "charging_site_device_disaster",
+    "charging_get_site_device_disaster_status": "charging_site_device_disaster_status",
+    "charging_get_disaster_support_func": "charging_disaster_support_func",
     "charging_energy_solar": "charging_energy_solar",
     "charging_energy_hes": "charging_energy_hes",
     "charging_energy_pps": "charging_energy_pps",

--- a/src/anker_solix_api/apitypes.py
+++ b/src/anker_solix_api/apitypes.py
@@ -215,6 +215,14 @@ API_CHARGING_ENDPOINTS: Final[dict] = {
     "get_configs": "charging_energy_service/get_configs",  # json={"siteId": "SITEID", "sn": "POWERPANELSN", "param_types": []})) # needs owner account, list of parm types not clear
     "get_sns": "charging_energy_service/get_sns",  # json={"main_sn": "POWERPANELSN","macs": ["F38001MAC001","F38002MAC002"]})) # needs owner account, Displays Serial Numbers of attached PPS in Home
     "get_monetary_units": "charging_energy_service/get_world_monetary_unit",  # monetary unit list for system, needs owner account
+    # Power Panel disaster preparedness / backup mode (verified on A17B1 hardware, use type=2)
+    "get_site_device_disaster": "charging_disaster_prepared/get_site_device_disaster",  # {"identifier_id": siteId, "type": 2}
+    "get_site_device_disaster_status": "charging_disaster_prepared/get_site_device_disaster_status",  # {"identifier_id": siteId, "type": 2}
+    "set_site_device_disaster": "charging_disaster_prepared/set_site_device_disaster",  # ON: switch True + manual_disaster_detail; OFF: switch False, omit detail
+    "get_disaster_support_func": "charging_disaster_prepared/get_support_func",  # {"identifier_id": siteId, "type": 2}
+    "quit_disaster_prepare": "charging_disaster_prepared/quit_disaster_prepare",
+    "disaster_clear": "charging_disaster_prepared/clear",
+    "disaster_detail": "charging_disaster_prepared/disaster_detail",
 }
 
 """Following are the Anker Power/Solix Cloud API charging_hes_svc endpoints known so far. They are used for Home Energy Systems like X1."""

--- a/src/anker_solix_api/powerpanel.py
+++ b/src/anker_solix_api/powerpanel.py
@@ -1572,3 +1572,83 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
                         }
                     )
         return entry
+
+    async def get_device_disaster(self, siteId: str, deviceType: int = 2) -> dict:
+        """Get the manual/auto backup (disaster preparedness) configuration of a Power Panel site.
+
+        Verified on A17B1 Home Power Panel. deviceType=2 for power panel sites.
+        Returns: auto_disaster_switch, manual_disaster_switch, disaster_details[].
+        """
+        data = {"identifier_id": siteId, "type": deviceType}
+        resp = await self.apisession.request(
+            "post", API_CHARGING_ENDPOINTS["get_site_device_disaster"], json=data
+        )
+        result = resp.get("data") or {}
+        self._update_site(siteId, {"device_disaster": result})
+        return result
+
+    async def get_device_disaster_status(self, siteId: str, deviceType: int = 2) -> dict:
+        """Get the live backup-preparedness status of a Power Panel site.
+
+        manual_disaster_status: 1 = active/running, 2 = inactive.
+        current_disaster_detail is populated only while a window is active.
+        """
+        data = {"identifier_id": siteId, "type": deviceType}
+        resp = await self.apisession.request(
+            "post", API_CHARGING_ENDPOINTS["get_site_device_disaster_status"], json=data
+        )
+        return resp.get("data") or {}
+
+    async def get_disaster_support(self, siteId: str, deviceType: int = 2) -> dict:
+        """Get backup feature support info (auto disaster support, allowed country codes)."""
+        data = {"identifier_id": siteId, "type": deviceType}
+        resp = await self.apisession.request(
+            "post", API_CHARGING_ENDPOINTS["get_disaster_support_func"], json=data
+        )
+        return resp.get("data") or {}
+
+    async def set_manual_backup(
+        self,
+        siteId: str,
+        start_time: int,
+        end_time: int,
+        disaster_type: int = 4,
+        deviceType: int = 2,
+    ) -> bool:
+        """Enable manual backup mode for a Power Panel site over a time window.
+
+        start_time / end_time are unix epoch seconds.
+        Note (verified): disaster_type 4 is accepted but stored/returned as 1;
+        the server auto-generates the event uuid.
+        """
+        data = {
+            "identifier_id": siteId,
+            "type": deviceType,
+            "manual_disaster_switch": True,
+            "manual_disaster_detail": {
+                "disaster_type": disaster_type,
+                "start_time": int(start_time),
+                "end_time": int(end_time),
+            },
+        }
+        resp = await self.apisession.request(
+            "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+        )
+        return bool((resp.get("data") or {}).get("success"))
+
+    async def disable_manual_backup(self, siteId: str, deviceType: int = 2) -> bool:
+        """Disable manual backup mode for a Power Panel site.
+
+        Note (verified): the OFF payload MUST omit manual_disaster_detail.
+        Sending manual_disaster_detail=None returns code:-1 'Failed to request.'.
+        The device ramps power down gradually rather than cutting off instantly.
+        """
+        data = {
+            "identifier_id": siteId,
+            "type": deviceType,
+            "manual_disaster_switch": False,
+        }
+        resp = await self.apisession.request(
+            "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+        )
+        return bool((resp.get("data") or {}).get("success"))

--- a/src/anker_solix_api/powerpanel.py
+++ b/src/anker_solix_api/powerpanel.py
@@ -1686,7 +1686,9 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
         else:
             code = (
                 await self.apisession.request(
-                    "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+                    "post",
+                    API_CHARGING_ENDPOINTS["set_site_device_disaster"],
+                    json=data,
                 )
             ).get("code")
             if not isinstance(code, int) or int(code) != 0:
@@ -1721,7 +1723,9 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
         else:
             code = (
                 await self.apisession.request(
-                    "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+                    "post",
+                    API_CHARGING_ENDPOINTS["set_site_device_disaster"],
+                    json=data,
                 )
             ).get("code")
             if not isinstance(code, int) or int(code) != 0:

--- a/src/anker_solix_api/powerpanel.py
+++ b/src/anker_solix_api/powerpanel.py
@@ -1573,38 +1573,73 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
                     )
         return entry
 
-    async def get_device_disaster(self, siteId: str, deviceType: int = 2) -> dict:
+    async def get_device_disaster(
+        self, siteId: str, deviceType: int = 2, fromFile: bool = False
+    ) -> dict:
         """Get the manual/auto backup (disaster preparedness) configuration of a Power Panel site.
 
-        Verified on A17B1 Home Power Panel. deviceType=2 for power panel sites.
+        Verified on A17B1 Home Power Panel, deviceType=2 for power panel sites.
         Returns: auto_disaster_switch, manual_disaster_switch, disaster_details[].
         """
-        data = {"identifier_id": siteId, "type": deviceType}
-        resp = await self.apisession.request(
-            "post", API_CHARGING_ENDPOINTS["get_site_device_disaster"], json=data
+        self._logger.debug(
+            "Getting api %s Power Panel disaster config", self.apisession.nickname
         )
+        data = {"identifier_id": siteId, "type": deviceType}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_site_device_disaster']}_{siteId}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_site_device_disaster"], json=data
+            )
         result = resp.get("data") or {}
-        self._update_site(siteId, {"device_disaster": result})
+        if result:
+            # cache under site_details so it is included in exports
+            self._update_site(siteId, {"device_disaster": result})
         return result
 
-    async def get_device_disaster_status(self, siteId: str, deviceType: int = 2) -> dict:
+    async def get_device_disaster_status(
+        self, siteId: str, deviceType: int = 2, fromFile: bool = False
+    ) -> dict:
         """Get the live backup-preparedness status of a Power Panel site.
 
         manual_disaster_status: 1 = active/running, 2 = inactive.
-        current_disaster_detail is populated only while a window is active.
+        current_disaster_detail is only populated while a window is active.
+        Note: status flips to 1 only once start_time is reached, back to 2 after end_time.
         """
-        data = {"identifier_id": siteId, "type": deviceType}
-        resp = await self.apisession.request(
-            "post", API_CHARGING_ENDPOINTS["get_site_device_disaster_status"], json=data
+        self._logger.debug(
+            "Getting api %s Power Panel disaster status", self.apisession.nickname
         )
+        data = {"identifier_id": siteId, "type": deviceType}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_site_device_disaster_status']}_{siteId}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post",
+                API_CHARGING_ENDPOINTS["get_site_device_disaster_status"],
+                json=data,
+            )
         return resp.get("data") or {}
 
-    async def get_disaster_support(self, siteId: str, deviceType: int = 2) -> dict:
+    async def get_disaster_support(
+        self, siteId: str, deviceType: int = 2, fromFile: bool = False
+    ) -> dict:
         """Get backup feature support info (auto disaster support, allowed country codes)."""
         data = {"identifier_id": siteId, "type": deviceType}
-        resp = await self.apisession.request(
-            "post", API_CHARGING_ENDPOINTS["get_disaster_support_func"], json=data
-        )
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_disaster_support_func']}_{siteId}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_disaster_support_func"], json=data
+            )
         return resp.get("data") or {}
 
     async def set_manual_backup(
@@ -1612,43 +1647,85 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
         siteId: str,
         start_time: int,
         end_time: int,
-        disaster_type: int = 4,
+        disaster_type: int = 1,
         deviceType: int = 2,
-    ) -> bool:
+        toFile: bool = False,
+    ) -> dict:
         """Enable manual backup mode for a Power Panel site over a time window.
 
-        start_time / end_time are unix epoch seconds.
-        Note (verified): disaster_type 4 is accepted but stored/returned as 1;
+        start_time / end_time are unix epoch seconds; end_time must be after start_time.
+        Note (verified): disaster_type other than 1 is accepted but stored/returned as 1;
         the server auto-generates the event uuid.
+        Returns the refreshed disaster configuration.
         """
+        start_time, end_time = int(start_time), int(end_time)
+        if end_time <= start_time:
+            self._logger.error(
+                "set_manual_backup: end_time %s must be after start_time %s",
+                end_time,
+                start_time,
+            )
+            return {}
         data = {
             "identifier_id": siteId,
             "type": deviceType,
             "manual_disaster_switch": True,
             "manual_disaster_detail": {
                 "disaster_type": disaster_type,
-                "start_time": int(start_time),
-                "end_time": int(end_time),
+                "start_time": start_time,
+                "end_time": end_time,
             },
         }
-        resp = await self.apisession.request(
-            "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+        if toFile:
+            if not await self.apisession.saveToFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_site_device_disaster']}_modified_{siteId}.json",
+                data={"code": 0, "msg": "success!", "data": data},
+            ):
+                return {}
+        else:
+            code = (
+                await self.apisession.request(
+                    "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+                )
+            ).get("code")
+            if not isinstance(code, int) or int(code) != 0:
+                return {}
+        # return refreshed config and update cache
+        return await self.get_device_disaster(
+            siteId=siteId, deviceType=deviceType, fromFile=toFile
         )
-        return bool((resp.get("data") or {}).get("success"))
 
-    async def disable_manual_backup(self, siteId: str, deviceType: int = 2) -> bool:
+    async def disable_manual_backup(
+        self, siteId: str, deviceType: int = 2, toFile: bool = False
+    ) -> dict:
         """Disable manual backup mode for a Power Panel site.
 
         Note (verified): the OFF payload MUST omit manual_disaster_detail.
         Sending manual_disaster_detail=None returns code:-1 'Failed to request.'.
         The device ramps power down gradually rather than cutting off instantly.
+        Returns the refreshed disaster configuration.
         """
         data = {
             "identifier_id": siteId,
             "type": deviceType,
             "manual_disaster_switch": False,
         }
-        resp = await self.apisession.request(
-            "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+        if toFile:
+            if not await self.apisession.saveToFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_site_device_disaster']}_modified_{siteId}.json",
+                data={"code": 0, "msg": "success!", "data": data},
+            ):
+                return {}
+        else:
+            code = (
+                await self.apisession.request(
+                    "post", API_CHARGING_ENDPOINTS["set_site_device_disaster"], json=data
+                )
+            ).get("code")
+            if not isinstance(code, int) or int(code) != 0:
+                return {}
+        return await self.get_device_disaster(
+            siteId=siteId, deviceType=deviceType, fromFile=toFile
         )
-        return bool((resp.get("data") or {}).get("success"))

--- a/test_powerpanel_disaster.py
+++ b/test_powerpanel_disaster.py
@@ -12,7 +12,7 @@ import logging
 from pathlib import Path
 
 from aiohttp import ClientSession
-from api.powerpanel import AnkerSolixPowerpanelApi  # pylint: disable=no-name-in-module
+from anker_solix_api.powerpanel import AnkerSolixPowerpanelApi  # pylint: disable=no-name-in-module
 import common
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)

--- a/test_powerpanel_disaster.py
+++ b/test_powerpanel_disaster.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Example exec module to test the Anker Power Panel manual backup (disaster preparedness) methods.
+
+By default it replays the responses captured in the example export folder via the
+fromFile mechanism, so it runs without contacting the cloud. Set TESTFROMFILE = False
+to run the read methods live against your own Power Panel account instead.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from aiohttp import ClientSession
+from api.powerpanel import AnkerSolixPowerpanelApi  # pylint: disable=no-name-in-module
+import common
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.StreamHandler())
+# _LOGGER.setLevel(logging.DEBUG)    # enable for detailed API output
+CONSOLE: logging.Logger = common.CONSOLE
+
+TESTFROMFILE = True
+# Example export folder and the Power Panel site id contained in it
+JSONFOLDER = "PowerPanel_ManualBackup"
+SITE_ID = "f6a1b2c3-d4e5-6789-abcd-ef0123456789"
+
+
+def _out(jsondata) -> None:
+    CONSOLE.info(json.dumps(jsondata, indent=2))
+
+
+async def test_disaster_methods(myapi: AnkerSolixPowerpanelApi) -> None:
+    """Exercise the Power Panel manual backup read methods."""
+    if TESTFROMFILE:
+        myapi.testDir(Path(Path(__file__).parent) / "examples" / JSONFOLDER)
+
+    CONSOLE.info("Backup configuration (get_device_disaster):")
+    _out(await myapi.get_device_disaster(siteId=SITE_ID, fromFile=TESTFROMFILE))
+
+    CONSOLE.info("Backup status (get_device_disaster_status):")
+    _out(await myapi.get_device_disaster_status(siteId=SITE_ID, fromFile=TESTFROMFILE))
+
+    CONSOLE.info("Backup support info (get_disaster_support):")
+    _out(await myapi.get_disaster_support(siteId=SITE_ID, fromFile=TESTFROMFILE))
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    CONSOLE.info("Testing Solix Power Panel manual backup methods:")
+    async with ClientSession() as websession:
+        myapi = AnkerSolixPowerpanelApi(
+            common.user(),
+            common.password(),
+            common.country(),
+            websession,
+            _LOGGER,
+        )
+        await test_disaster_methods(myapi)
+
+
+# run async main
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        CONSOLE.warning("\nAborted!")
+    except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        CONSOLE.exception("%s: %s", type(err), err)


### PR DESCRIPTION
Adds read/write methods to the `AnkerSolixPowerpanelApi` for the Home Power Panel "manual backup / disaster preparedness" feature, verified on A17B1 hardware (owner account, `type=2`).

### New endpoints (`API_CHARGING_ENDPOINTS`)
`get_site_device_disaster`, `get_site_device_disaster_status`, `set_site_device_disaster`, `get_disaster_support_func`.

### New methods (`AnkerSolixPowerpanelApi`)
- `get_device_disaster`, `get_device_disaster_status`, `get_disaster_support` — read methods, support `fromFile`; the config is cached into `site_details`.
- `set_manual_backup`, `disable_manual_backup` — setters, support `toFile`, check the response `code`, and return the refreshed configuration.

### Verified behaviour
- **Enable:** `manual_disaster_switch=True` plus `manual_disaster_detail{disaster_type, start_time, end_time}`.
- **Disable:** `manual_disaster_switch=False` with the detail **omitted** — sending `manual_disaster_detail=None` returns `code:-1 "Failed to request."`.
- `manual_disaster_status` is `1` while inside the active window and `2` otherwise (it flips at `start_time` / `end_time`).
- `disaster_type` is normalised to `1` by the server and the event uuid is server-generated.
- Tested on an owner account only; member/shared-account behaviour is not verified.

### Test
Adds `test_powerpanel_disaster.py` and an `examples/PowerPanel_ManualBackup/` snapshot so the read methods can be exercised offline via the existing `fromFile` mechanism (`TESTFROMFILE = True` by default).
