### PR TITLE
Add Power Panel endpoint methods: TOU rate plan (read/write), device/wifi info, etc.

### DIFF
--- a/examples/PowerPanel_ReadEndpoints/charging_device_info_UUBABYAH2ONIAPD4.json
+++ b/examples/PowerPanel_ReadEndpoints/charging_device_info_UUBABYAH2ONIAPD4.json
@@ -1,0 +1,18 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "device_infos": [
+      {
+        "sn": "UUBABYAH2ONIAPD4",
+        "device_type": "A17B1",
+        "ble_bind_type": 2,
+        "ble_mac": "FFB7B7D7A1D6",
+        "wifi_bind_type": 2,
+        "connect": true,
+        "site_id": "492cbe8c-e2a9-b6c4-c7ee-45b3ef4260e0"
+      }
+    ]
+  },
+  "trace_id": "bdf3881ef10f2ca0809afe767edccfa8"
+}

--- a/examples/PowerPanel_ReadEndpoints/charging_installation_inspection_UUBABYAH2ONIAPD4.json
+++ b/examples/PowerPanel_ReadEndpoints/charging_installation_inspection_UUBABYAH2ONIAPD4.json
@@ -1,0 +1,11 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "latest_result": true,
+    "latest_time": 1758515431,
+    "latest_page": "/electricityScene",
+    "need_self_inspection": true
+  },
+  "trace_id": "a4f0bc26b86fa6cd61b01c3efc4b93ab"
+}

--- a/examples/PowerPanel_ReadEndpoints/charging_monetary_units_UUBABYAH2ONIAPD4.json
+++ b/examples/PowerPanel_ReadEndpoints/charging_monetary_units_UUBABYAH2ONIAPD4.json
@@ -1,0 +1,64 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "price_units": [
+      {
+        "price_unit": "$",
+        "is_default": true,
+        "name": "AUD, CAD, USD"
+      },
+      {
+        "price_unit": "\u043b\u0432",
+        "is_default": false,
+        "name": "BGN"
+      },
+      {
+        "price_unit": "CHF",
+        "is_default": false,
+        "name": "CHF"
+      },
+      {
+        "price_unit": "K\u010d",
+        "is_default": false,
+        "name": "CZK"
+      },
+      {
+        "price_unit": "\u20ac",
+        "is_default": false,
+        "name": "EUR"
+      },
+      {
+        "price_unit": "\u00a3",
+        "is_default": false,
+        "name": "GBP"
+      },
+      {
+        "price_unit": "Ft",
+        "is_default": false,
+        "name": "HUF"
+      },
+      {
+        "price_unit": "kr",
+        "is_default": false,
+        "name": "ISK, NOK, SEK"
+      },
+      {
+        "price_unit": "\u00a5",
+        "is_default": false,
+        "name": "JPY"
+      },
+      {
+        "price_unit": "z\u0142",
+        "is_default": false,
+        "name": "PLN"
+      },
+      {
+        "price_unit": "Lei",
+        "is_default": false,
+        "name": "RON"
+      }
+    ]
+  },
+  "trace_id": "c603e8260f64fcf87adc8b65fb70c09f"
+}

--- a/examples/PowerPanel_ReadEndpoints/charging_sns_UUBABYAH2ONIAPD4.json
+++ b/examples/PowerPanel_ReadEndpoints/charging_sns_UUBABYAH2ONIAPD4.json
@@ -1,0 +1,10 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "mac_sn_map": {
+      "FFB7B7D7A1D6": ""
+    }
+  },
+  "trace_id": "f97f7ca9c5fbafedfdf4c4f9aad36eed"
+}

--- a/examples/PowerPanel_ReadEndpoints/charging_utility_rate_plan_UUBABYAH2ONIAPD4.json
+++ b/examples/PowerPanel_ReadEndpoints/charging_utility_rate_plan_UUBABYAH2ONIAPD4.json
@@ -1,0 +1,84 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "peak_sessions": [
+      {
+        "id": 44138,
+        "name": "\u5b63\u82821",
+        "start_time": "2026-01-01 00:00:00",
+        "start_desc": "January",
+        "end_time": "2026-12-01 00:00:00",
+        "end_desc": "December",
+        "type": 2,
+        "peak_valley_prices": [
+          {
+            "id": 280199,
+            "buy": 0.03,
+            "energy_unit": "kWh",
+            "start_time_period": "00:00",
+            "end_time_period": "16:00",
+            "peak_type": 1,
+            "day_type": 2
+          },
+          {
+            "id": 280200,
+            "buy": 0.39,
+            "energy_unit": "kWh",
+            "start_time_period": "16:00",
+            "end_time_period": "21:00",
+            "peak_type": 4,
+            "day_type": 2
+          },
+          {
+            "id": 280201,
+            "buy": 0.15,
+            "energy_unit": "kWh",
+            "start_time_period": "21:00",
+            "end_time_period": "23:00",
+            "peak_type": 3,
+            "day_type": 2
+          },
+          {
+            "id": 280202,
+            "buy": 0.03,
+            "energy_unit": "kWh",
+            "start_time_period": "23:00",
+            "end_time_period": "24:00",
+            "peak_type": 1,
+            "day_type": 2
+          },
+          {
+            "id": 280203,
+            "buy": 0.03,
+            "energy_unit": "kWh",
+            "start_time_period": "00:00",
+            "end_time_period": "07:00",
+            "peak_type": 1,
+            "day_type": 1
+          },
+          {
+            "id": 280204,
+            "buy": 0.09,
+            "energy_unit": "kWh",
+            "start_time_period": "07:00",
+            "end_time_period": "23:00",
+            "peak_type": 2,
+            "day_type": 1
+          },
+          {
+            "id": 280205,
+            "buy": 0.03,
+            "energy_unit": "kWh",
+            "start_time_period": "23:00",
+            "end_time_period": "24:00",
+            "peak_type": 1,
+            "day_type": 1
+          }
+        ]
+      }
+    ],
+    "fixed_price": null
+  },
+  "trace_id": "ac3ee7ebaeaa8ae2eba144676eb3e9f4"
+}

--- a/examples/PowerPanel_ReadEndpoints/charging_wifi_info_UUBABYAH2ONIAPD4.json
+++ b/examples/PowerPanel_ReadEndpoints/charging_wifi_info_UUBABYAH2ONIAPD4.json
@@ -1,0 +1,9 @@
+{
+  "code": 0,
+  "msg": "success!",
+  "data": {
+    "ssid": "wifi-network-1",
+    "rssi": 100
+  },
+  "trace_id": "59fddaf719893fa58ebcf1822b8941a6"
+}

--- a/src/anker_solix_api/apitypes.py
+++ b/src/anker_solix_api/apitypes.py
@@ -211,6 +211,8 @@ API_CHARGING_ENDPOINTS: Final[dict] = {
     "get_wifi_info": "charging_energy_service/get_wifi_info",  # Displays WiFi network connected to Home Power Panel, needs owner account
     "get_installation_inspection": "charging_energy_service/get_installation_inspection",  # appears to say which page last viewed on App, needs owner account
     "get_utility_rate_plan": "charging_energy_service/get_utility_rate_plan",  # needs owner account
+    "preprocess_utility_rate_plan": "charging_energy_service/preprocess_utility_rate_plan",  # needs owner, json={"siteId", "sn", "peak_sessions", "fixed_price"}, returns {"rule": compact tier schedule}
+    "ack_utility_rate_plan": "charging_energy_service/ack_utility_rate_plan",  # needs owner, json={"siteId", "sn", "rule", "peak_sessions", "fixed_price"}, commits the TOU plan (verified reversible on A17B1); rule drops prices, so full peak_sessions + fixed_price must be included
     "report_device_data": "charging_energy_service/report_device_data",  # ctrol [0 1], works but data is null (may need owner account?)
     "get_configs": "charging_energy_service/get_configs",  # json={"siteId": "SITEID", "sn": "POWERPANELSN", "param_types": []})) # needs owner account, list of parm types not clear
     "get_sns": "charging_energy_service/get_sns",  # json={"main_sn": "POWERPANELSN","macs": ["F38001MAC001","F38002MAC002"]})) # needs owner account, Displays Serial Numbers of attached PPS in Home
@@ -485,14 +487,10 @@ Home Energy System related (X1): 6 + 0 used => 6 total
     "charging_hes_dynamic_price_svc/save_dynamic_price", # needs owner
     "charging_hes_dynamic_price_svc/get_third_jump_url"
 
-related to what, seem to work with Power Panel sites: 7 + 0 used => 7 total
-    'charging_disaster_prepared/get_site_device_disaster', # {"identifier_id": siteId, "type": 2})) # works with Power panel site and shared account
-    'charging_disaster_prepared/get_site_device_disaster_status', # {"identifier_id": siteId, "type": 2})) # works with Power panel site and shared account
-    'charging_disaster_prepared/set_site_device_disaster',
+related to what, seem to work with Power Panel sites: 3 + 4 used => 7 total
     'charging_disaster_prepared/clear',
     'charging_disaster_prepared/quit_disaster_prepare',
-    'charging_disaster_prepared/get_support_func', # {"identifier_id": siteId, "type": 2})) # works with Power panel site and shared account
-    'charging_disaster_prepared/disaster_detail',
+    'charging_disaster_prepared/disaster_detail', # 404 page not found (verified on A17B1)
 
 related to Prime charger models: 22 + 9 used => 31 total
     'mini_power/v1/app/charging/update_charging_mode',
@@ -648,7 +646,6 @@ API_FILEPREFIXES: Final[dict] = {
     "charging_get_configs": "charging_configs",
     "charging_get_sns": "charging_sns",
     "charging_get_monetary_units": "charging_monetary_units",
-    # charging_energy_service endpoint file prefixes
     "hes_get_product_info": "hes_product_info",
     "hes_get_heat_pump_plan": "hes_heat_pump_plan",
     "hes_get_electric_plan_list": "hes_electric_plan",

--- a/src/anker_solix_api/export.py
+++ b/src/anker_solix_api/export.py
@@ -1383,19 +1383,39 @@ class AnkerSolixApiExport:
                         payload={
                             "siteId": siteId,
                             "sn": sn,
-                        },  # TODO: required parameters unknown
+                        },  # payload verified on A17B1 owner account
                         replace=[(siteId, "<siteId>"), (sn, "<deviceSn>")],
                         admin=admin,
                     )
                     self._logger.info("Exporting %s info...", dev_type)
                     # works only for site owners
-                    await self.query(
+                    response = await self.query(
                         endpoint=API_CHARGING_ENDPOINTS["get_device_info"],
                         filename=f"{API_FILEPREFIXES['charging_get_device_info']}_{self._randomize(sn, '_sn')}.json",
                         payload={"siteId": siteId, "sns": [sn]},
                         replace=[(siteId, "<siteId>"), (sn, "<deviceSn>")],
                         admin=admin,
                     )
+                    # resolve serials of attached devices from their mac addresses
+                    if macs := [
+                        str(dev.get("ble_mac"))
+                        for dev in (response or {})
+                        .get("data", {})
+                        .get("device_infos", [])
+                        if dev.get("ble_mac")
+                    ]:
+                        self._logger.info(
+                            "Exporting %s attached device serials...", dev_type
+                        )
+                        # works only for site owners
+                        await self.query(
+                            endpoint=API_CHARGING_ENDPOINTS["get_sns"],
+                            filename=f"{API_FILEPREFIXES['charging_get_sns']}_{self._randomize(sn, '_sn')}.json",
+                            payload={"main_sn": sn, "macs": macs},
+                            replace=[(siteId, "<siteId>"), (sn, "<deviceSn>")],
+                            admin=admin,
+                            randomkeys=True,
+                        )
 
                 # run for proper device types if site owner
                 if dev_type in [
@@ -1421,7 +1441,8 @@ class AnkerSolixApiExport:
                     await self.query(
                         endpoint=API_CHARGING_ENDPOINTS["get_installation_inspection"],
                         filename=f"{API_FILEPREFIXES['charging_get_installation_inspection']}_{self._randomize(sn, '_sn')}.json",
-                        payload={"sn": sn},
+                        # siteId + sn payload verified on A17B1 owner account
+                        payload={"siteId": siteId, "sn": sn} if siteId else {"sn": sn},
                         replace=[(siteId, "<siteId>"), (sn, "<deviceSn>")],
                         admin=admin,
                     )

--- a/src/anker_solix_api/powerpanel.py
+++ b/src/anker_solix_api/powerpanel.py
@@ -180,8 +180,8 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
                         device.update({key: bool(value)})
                     # key with string values
                     elif key == "wireless_type" or (
-                        # Example for key with string values that should only be updated if value returned
-                        key == "wifi_name" and value
+                        # Example for keys with string values that should only be updated if value returned
+                        key in ["wifi_name", "rssi"] and value
                     ):
                         device.update({key: str(value)})
                     # check that main device is defined for all sub devices
@@ -511,6 +511,25 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
                         self.apisession.nickname,
                     )
                     await self.get_site_price(siteId=site_id, fromFile=fromFile)
+                # Fetch utility rate plan (TOU) of the main Power Panel device
+                if {ApiCategories.site_price} - exclude and (
+                    main_sn := next(
+                        (
+                            sn
+                            for sn, dev in self.devices.items()
+                            if dev.get("site_id") == site_id
+                            and dev.get("type") == SolixDeviceType.POWERPANEL.value
+                        ),
+                        None,
+                    )
+                ):
+                    self._logger.debug(
+                        "Getting api %s utility rate plan for site",
+                        self.apisession.nickname,
+                    )
+                    await self.get_utility_rate_plan(
+                        siteId=site_id, deviceSn=main_sn, fromFile=fromFile
+                    )
             # Fetch details that work for all account types
             # Fetch CO2 Ranking if not excluded
             if not ({ApiCategories.powerpanel_energy} & exclude):
@@ -611,10 +630,18 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
             "Updating api %s Power Panel Device details",
             self.apisession.nickname,
         )
-        #
-        # Implement required queries according to exclusion set
-        #
-
+        for sn, device in self.devices.items():
+            if device.get("type") in (
+                {SolixDeviceType.POWERPANEL.value} - exclude
+            ) and device.get("is_admin", False):
+                # Fetch wifi info of the Power Panel, since bind_devices does not
+                # report the rssi of the panel itself (attached PPS devices are
+                # already covered by bind_devices, so they are skipped here)
+                self._logger.debug(
+                    "Getting api %s wifi info for device",
+                    self.apisession.nickname,
+                )
+                await self.get_wifi_info(deviceSn=sn, fromFile=fromFile)
         return self.devices
 
     async def get_system_running_info(
@@ -1732,4 +1759,237 @@ class AnkerSolixPowerpanelApi(AnkerSolixBaseApi):
                 return {}
         return await self.get_device_disaster(
             siteId=siteId, deviceType=deviceType, fromFile=toFile
+        )
+
+    async def get_utility_rate_plan(
+        self, siteId: str, deviceSn: str, fromFile: bool = False
+    ) -> dict:
+        """Get the Time-of-Use (TOU) utility rate plan of a Power Panel site.
+
+        Verified on A17B1 Home Power Panel (owner account).
+        Returns peak_sessions[] (each with peak_valley_prices: buy price per time
+        period, peak_type 1-4, day_type) and fixed_price.
+
+        Example data:
+        {"peak_sessions": [{"id": 10001,"name": "Season 1","start_time": "2026-01-01 00:00:00","start_desc": "January",
+            "end_time": "2026-12-01 00:00:00","end_desc": "December","type": 2,"peak_valley_prices": [
+            {"id": 20001,"buy": 0.03,"energy_unit": "kWh","start_time_period": "00:00","end_time_period": "16:00","peak_type": 1,"day_type": 2},
+            {"id": 20002,"buy": 0.39,"energy_unit": "kWh","start_time_period": "16:00","end_time_period": "21:00","peak_type": 4,"day_type": 2},
+            {"id": 20006,"buy": 0.09,"energy_unit": "kWh","start_time_period": "07:00","end_time_period": "23:00","peak_type": 2,"day_type": 1}]}],
+        "fixed_price": null}
+        """
+        self._logger.debug(
+            "Getting api %s Power Panel utility rate plan", self.apisession.nickname
+        )
+        data = {"siteId": siteId, "sn": deviceSn}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_utility_rate_plan']}_{deviceSn}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_utility_rate_plan"], json=data
+            )
+        result = resp.get("data") or {}
+        if result:
+            # cache under site_details so it is included in exports
+            self._update_site(siteId, {"utility_rate_plan": result})
+        return result
+
+    async def get_monetary_units(self, deviceSn: str, fromFile: bool = False) -> dict:
+        """Get the list of supported monetary/price units (currencies) for the system.
+
+        Example data:
+        {"price_units": [{"price_unit": "$","is_default": true,"name": "AUD, CAD, USD"},
+            {"price_unit": "€","is_default": false,"name": "EUR"},{"price_unit": "£","is_default": false,"name": "GBP"}]}
+        """
+        data = {"sn": deviceSn}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_monetary_units']}_{deviceSn}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_monetary_units"], json=data
+            )
+        return resp.get("data") or {}
+
+    async def get_device_info(
+        self, deviceSns: list[str], fromFile: bool = False
+    ) -> dict:
+        """Get Wi-Fi / MAC binding info for the provided device serials.
+
+        Works for the Home Power Panel and its attached PPS serials.
+        Returns device_infos[] with device_type, ble_mac, wifi_bind_type, connect, site_id.
+
+        Example data:
+        {"device_infos": [
+            {"sn": "AZVABY0F00000001","device_type": "A17B1","ble_bind_type": 2,"ble_mac": "F49D8A000001","wifi_bind_type": 2,"connect": true,"site_id": "f6a1b2c3-d4e5-6789-abcd-ef0123456789"},
+            {"sn": "AZVBH30D00000001","device_type": "A1790","ble_bind_type": 2,"ble_mac": "E8EECC000001","wifi_bind_type": 2,"connect": false,"site_id": ""}]}
+        """
+        data = {"sns": list(deviceSns)}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_device_info']}_{next(iter(deviceSns), '')}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_device_info"], json=data
+            )
+        return resp.get("data") or {}
+
+    async def get_wifi_info(self, deviceSn: str, fromFile: bool = False) -> dict:
+        """Get the Wi-Fi network (ssid, rssi) the given device is connected to.
+
+        Example data:
+        {"ssid": "wifi-network-1", "rssi": 100}
+        """
+        data = {"sn": deviceSn}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_wifi_info']}_{deviceSn}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_wifi_info"], json=data
+            )
+        result = resp.get("data") or {}
+        # update device cache with wifi details, since bind_devices does not report
+        # the rssi of the Power Panel itself
+        if result:
+            devdata = {"device_sn": deviceSn}
+            if str(result.get("ssid") or ""):
+                devdata["wifi_name"] = str(result.get("ssid"))
+            if str(result.get("rssi") or ""):
+                devdata["rssi"] = str(result.get("rssi"))
+            self._update_dev(devdata)
+        return result
+
+    async def get_installation_inspection(
+        self, siteId: str, deviceSn: str, fromFile: bool = False
+    ) -> dict:
+        """Get the installation/self-inspection status of a Power Panel site.
+
+        Returns latest_result, latest_time, latest_page (last App page viewed)
+        and need_self_inspection.
+
+        Example data:
+        {"latest_result": true, "latest_time": 1758515431, "latest_page": "/electricityScene", "need_self_inspection": true}
+        """
+        data = {"siteId": siteId, "sn": deviceSn}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_installation_inspection']}_{deviceSn}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post",
+                API_CHARGING_ENDPOINTS["get_installation_inspection"],
+                json=data,
+            )
+        return resp.get("data") or {}
+
+    async def get_device_sns(
+        self, mainSn: str, macs: list[str], fromFile: bool = False
+    ) -> dict:
+        """Resolve attached device MAC addresses to serial numbers for a Power Panel.
+
+        Returns {"mac_sn_map": {<mac>: <sn>}}; the main device's own MAC maps to "".
+
+        Example data:
+        {"mac_sn_map": {"E8EECC000001": "AZVBH30D00000001","E8EECC000002": "AZVBH30D00000002","F49D8A000001": ""}}
+        """
+        data = {"main_sn": mainSn, "macs": list(macs)}
+        if fromFile:
+            resp = await self.apisession.loadFromFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_sns']}_{mainSn}.json"
+            )
+        else:
+            resp = await self.apisession.request(
+                "post", API_CHARGING_ENDPOINTS["get_sns"], json=data
+            )
+        return resp.get("data") or {}
+
+    async def set_utility_rate_plan(
+        self,
+        siteId: str,
+        deviceSn: str,
+        peak_sessions: list,
+        fixed_price: float | None = None,
+        toFile: bool = False,
+    ) -> dict:
+        """Set (replace) the Time-of-Use (TOU) utility rate plan of a Power Panel site.
+
+        Two-step cloud flow, verified reversible on A17B1 (owner account):
+        preprocess_utility_rate_plan compiles the peak_sessions into a compact
+        "rule" string, then ack_utility_rate_plan commits
+        {rule, peak_sessions, fixed_price}. Returns the refreshed plan.
+
+        peak_sessions uses the same structure returned by get_utility_rate_plan
+        (each session has peak_valley_prices with buy/start_time_period/
+        end_time_period/peak_type/day_type).
+
+        Example "rule" returned by preprocess (compact schedule encoding):
+        [{"Sea":{"S":1,"E":12},"P1":[{"S":0,"E":16,"T":3},{"S":16,"E":21,"T":1},{"S":21,"E":23,"T":1},{"S":23,"E":24,"T":3}],
+          "P2":[{"S":0,"E":7,"T":3},{"S":7,"E":23,"T":2},{"S":23,"E":24,"T":3}]}]
+        Sea = season start/end month, P1/P2 = hourly segments for day_type 2/1,
+        S/E = hour boundaries (0-24), T = price tier (T3 = off-peak, T2 = mid-peak,
+        T1 = peak). The rule string does NOT carry the prices, which is why ack
+        must include the full peak_sessions and fixed_price alongside it.
+        """
+        if not isinstance(peak_sessions, list):
+            self._logger.error("set_utility_rate_plan: peak_sessions must be a list")
+            return {}
+        data = {
+            "siteId": siteId,
+            "sn": deviceSn,
+            "peak_sessions": peak_sessions,
+            "fixed_price": fixed_price,
+        }
+        if toFile:
+            if not await self.apisession.saveToFile(
+                Path(self.testDir())
+                / f"{API_FILEPREFIXES['charging_get_utility_rate_plan']}_modified_{deviceSn}.json",
+                data={
+                    "code": 0,
+                    "msg": "success!",
+                    "data": {"peak_sessions": peak_sessions, "fixed_price": fixed_price},
+                },
+            ):
+                return {}
+        else:
+            rule = (
+                (
+                    await self.apisession.request(
+                        "post",
+                        API_CHARGING_ENDPOINTS["preprocess_utility_rate_plan"],
+                        json=data,
+                    )
+                ).get("data")
+                or {}
+            ).get("rule")
+            code = (
+                await self.apisession.request(
+                    "post",
+                    API_CHARGING_ENDPOINTS["ack_utility_rate_plan"],
+                    json={
+                        "siteId": siteId,
+                        "sn": deviceSn,
+                        "rule": rule,
+                        "peak_sessions": peak_sessions,
+                        "fixed_price": fixed_price,
+                    },
+                )
+            ).get("code")
+            if not isinstance(code, int) or int(code) != 0:
+                return {}
+        # return refreshed plan and update cache
+        return await self.get_utility_rate_plan(
+            siteId=siteId, deviceSn=deviceSn, fromFile=toFile
         )

--- a/test_powerpanel_endpoints.py
+++ b/test_powerpanel_endpoints.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""Example exec module to test the Anker Power Panel read-only endpoint methods.
+
+By default it replays the responses captured in the example export folder via the
+fromFile mechanism, so it runs without contacting the cloud. Set TESTFROMFILE = False
+to run the methods live against your own Power Panel account instead.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from aiohttp import ClientSession
+
+from anker_solix_api.powerpanel import AnkerSolixPowerpanelApi  # pylint: disable=no-name-in-module
+import common
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.StreamHandler())
+# _LOGGER.setLevel(logging.DEBUG)    # enable for detailed API output
+CONSOLE: logging.Logger = common.CONSOLE
+
+TESTFROMFILE = True
+# Example export folder and identifiers contained in it
+JSONFOLDER = "PowerPanel_ReadEndpoints"
+SITE_ID = "492cbe8c-e2a9-b6c4-c7ee-45b3ef4260e0"
+HPP_SN = "UUBABYAH2ONIAPD4"
+PPS_MACS = ["FFB7B7D7A1D6"]
+
+
+def _out(jsondata) -> None:
+    CONSOLE.info(json.dumps(jsondata, indent=2, ensure_ascii=False))
+
+
+async def test_read_methods(myapi: AnkerSolixPowerpanelApi) -> None:
+    """Exercise the Power Panel read-only methods."""
+    if TESTFROMFILE:
+        myapi.testDir(Path(Path(__file__).parent) / "examples" / JSONFOLDER)
+
+    ff = TESTFROMFILE
+    CONSOLE.info("Utility rate plan (TOU):")
+    _out(
+        await myapi.get_utility_rate_plan(siteId=SITE_ID, deviceSn=HPP_SN, fromFile=ff)
+    )
+    CONSOLE.info("Monetary units:")
+    _out(await myapi.get_monetary_units(deviceSn=HPP_SN, fromFile=ff))
+    CONSOLE.info("Device info:")
+    _out(await myapi.get_device_info(deviceSns=[HPP_SN], fromFile=ff))
+    CONSOLE.info("Wi-Fi info:")
+    _out(await myapi.get_wifi_info(deviceSn=HPP_SN, fromFile=ff))
+    CONSOLE.info("Installation inspection:")
+    _out(
+        await myapi.get_installation_inspection(
+            siteId=SITE_ID, deviceSn=HPP_SN, fromFile=ff
+        )
+    )
+    CONSOLE.info("Device SNs (mac -> sn):")
+    _out(await myapi.get_device_sns(mainSn=HPP_SN, macs=PPS_MACS, fromFile=ff))
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    CONSOLE.info("Testing Solix Power Panel read-only endpoint methods:")
+    async with ClientSession() as websession:
+        myapi = AnkerSolixPowerpanelApi(
+            common.user(),
+            common.password(),
+            common.country(),
+            websession,
+            _LOGGER,
+        )
+        await test_read_methods(myapi)
+
+
+# run async main
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        CONSOLE.warning("\nAborted!")
+    except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        CONSOLE.exception("%s: %s", type(err), err)


### PR DESCRIPTION
Adds methods to `AnkerSolixPowerpanelApi` for several `charging_energy_service` endpoints, verified on A17B1 hardware (owner account). Read methods use endpoint keys and file prefixes that already existed in `apitypes.py`; the TOU write flow adds two new endpoints there (`preprocess`/`ack_utility_rate_plan`).

### New methods
- **`get_utility_rate_plan(siteId, deviceSn)`** — the Time-of-Use (TOU) rate plan: `peak_sessions[]` with `peak_valley_prices` (buy price per time period, `peak_type` 1-4, `day_type`) and `fixed_price`. Cached into `site_details`.
- `get_monetary_units(deviceSn)` — supported price/currency units.
- `get_device_info(deviceSns)` — Wi-Fi/MAC binding info for the HPP and its attached PPS serials.
- `get_wifi_info(deviceSn)` — connected Wi-Fi `ssid` / `rssi`.
- `get_installation_inspection(siteId, deviceSn)` — `latest_result` / `latest_time` / `latest_page` (last App page viewed) / `need_self_inspection`.
- `get_device_sns(mainSn, macs)` — resolves attached device MAC addresses to serials (`mac_sn_map`).
- `set_utility_rate_plan(siteId, deviceSn, peak_sessions, fixed_price)` — replaces the TOU plan via the two-step preprocess/ack cloud flow (verified reversible on A17B1); the compact "rule" string from preprocess drops prices, so ack carries the full plan.

All support `fromFile`.

### Confirmed payloads (owner account)
- `get_utility_rate_plan` / `get_installation_inspection`: `{"siteId", "sn"}`
- `get_device_info`: `{"sns": [...]}`
- `get_wifi_info` / `get_monetary_units`: `{"sn"}`
- `get_sns`: `{"main_sn", "macs": [...]}` -> `{"mac_sn_map": {mac: sn}}`

### Test
Adds `test_powerpanel_endpoints.py` and an `examples/PowerPanel_ReadEndpoints/` snapshot (taken from a real randomized account export) so the methods can be exercised offline via the existing `fromFile` mechanism (`TESTFROMFILE = True` by default).

Note: `report_device_data` returns `data: null` even on the owner account, and `get_configs` succeeds but returns empty `configs` for `param_types` 1-20, so I left those two out.
