### PR TITLE
Fix and extend Power Panel _PP_JSON MQTT mappings from field validation (A17B1)

### DIFF
--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -4054,18 +4054,24 @@ _PP_JSON = {
         "g2lp": {NAME: "grid_to_home_power"},  # 1409 W
         "lp": {NAME: "ac_output_power"},  # 1409 W
         "mpp": {NAME: "micro_inverter_power"},  # 0 W
-        "op": {NAME: "other_power"},  # 0 W
+        "op": {NAME: "other_power"},  # 0 W, 3rd party PV channel, constant 0 when installation_method = 2 (none installed)
         "o2lp": {NAME: "other_to_home_power"},  # 0 W
         "o2pp": {NAME: "other_to_pv_power?"},  # 0 W
         "gmp": {NAME: "max_load_power?"},  # 4800 W
-        # disaster protection
-        "dpp": {NAME: "disaster_protection_plan_{x}"},  # list with mappings
-        "dps": {NAME: "disaster_protection_status?"},  # 0
+        # disaster protection (verified 2026-06 with manual backup plans and breaker test)
+        "dpp": {
+            NAME: "disaster_protection_plan_{x}"
+        },  # list with next scheduled backup plan(s), e.g. {"start": <epoch>, "end": <epoch>, "type": 1, "soc": 100}, pushed once scheduled in App
+        "dps": {NAME: "disaster_protection_status"},  # 1 while a backup plan is executing, else 0
+        "dpct": {
+            NAME: "charging_time"
+        },  # estimated charge time remaining, decreases with rising charge power; same value as charging_time in HTTP responses; 0 without active charge plan
+        "scfg": {NAME: "storm_config?"},  # constant 7 observed; Storm Guard toggles do not change it (cloud side setting)
         # status
-        "ws": {NAME: "working_status?"},  # 0 = standby, 1 = running
-        "m": {NAME: "mode"},  # (0 = off, 1 = on, 2 = auto)
-        "gs": {NAME: "grid_status?"},  # (0 = offline, 1 = online)
-        "bs": {  # 0: Standby; 1: Charging; 2: Discharging
+        "ws": {NAME: "working_status?"},  # 1 = running in 0500/0505; 0502 carries Wi-Fi signal % in same key (see _PP_JSON_0502)
+        "m": {NAME: "mode"},  # 2 = schedule based strategy (TOU plan), 1 = strategy without schedule (self consumption, fixed rate); verified by mode switching
+        "gs": {NAME: "grid_status"},  # 0 = on-grid, 1 = grid outage (verified by breaker test)
+        "bs": {  # 1: Standby; 2: Charging; 3: Discharging (verified against App); 0 never observed, deep sleep stops 0500 telemetry instead
             NAME: "battery_status"
         },
         "ps": {  # 0: Off, 1: On-grid
@@ -4074,16 +4080,32 @@ _PP_JSON = {
         "soc": {NAME: "battery_soc"},  # 62 %
         "b1t": {NAME: "battery_1_temperature"},
         "bc": {NAME: "pps_count?"},  # 2
-        "90s": {NAME: "pps_count"},  # 2
+        "90s": {NAME: "pps_count"},  # 2 in 0500/0505; 0502 carries an incrementing counter in same key (see _PP_JSON_0502)
         "bds": {
             NAME: "device_{x}_data"
         },  # list with PPS data dict, eg {"sn": <pps_sn>,"soc":61,"power":-1148,"error":0}
-        "cp": {NAME: "battery_soc_total?"},  # %
+        "cp": {NAME: "backup_reserve"},  # % SOC reserved for outage (verified: follows App setting changes)
         "pu": {NAME: "power_usage_mode?"},
+        "inmt": {
+            NAME: "installation_method"
+        },  # 3rd party PV wiring: 0 = unified circuit, 1 = separate circuit (CT at grid), 2 = no 3rd party PV (verified via App setting)
+        "tv": {NAME: "sw_version_3?"},  # "v1.6.3", observed same as mv
+        "acc": {NAME: "country_code"},  # "US"
+        "90aacc": {NAME: "device_1_country_code"},  # "US"
+        "90bacc": {NAME: "device_2_country_code"},  # "US"
+        "b1e": {NAME: "battery_1_error?"},  # 0
+        "tu": {NAME: "temperature_unit?"},  # 1
+        "ep": {NAME: "ep_unknown?"},  # constant 0 observed, does not change during grid outage
+        "os": {NAME: "os_unknown?"},  # constant 0 observed, does not change during grid outage
+        "ts": {NAME: "ts_unknown?"},  # constant 0 observed, does not change during grid outage
+        "b1s": {NAME: "battery_1_status?"},  # 0502 only, 1 observed
+        "fe": {NAME: "fe_energy?"},  # 0502 only, fluctuates non-monotonic (~268000-272000), possibly alternating per PPS
+        "status": {NAME: "event_status?"},  # observed 1 in event message at grid outage start
+        "code": {NAME: "event_code?"},  # observed 105 in event message at grid outage start
         "mps": {NAME: "micro_power_setting?"},
         "tpp": {NAME: "pv_power_total?"},  # 3045970
-        "tgp": {NAME: "grid_power_signed_total?"},  # 3045970
-        "tlp": {NAME: "home_load_total?"},  # 50620729
+        "tgp": {NAME: "grid_import_energy_total?"},  # cumulative counter, increase rate proportional to grid import power, halts during outage
+        "tlp": {NAME: "home_usage_energy_total?"},  # cumulative counter, increase rate proportional to home load power
         "tsp": {NAME: "battery_power_total?"},  # 50620729
         # daily energies in Wh?
         "pe": {NAME: "pv_yield_today", FACTOR: 0.001},  # 6293 Wh
@@ -4109,6 +4131,16 @@ _PP_JSON = {
         "pae": {NAME: "pv_yield", FACTOR: 0.001},  # 3045970 Wh
         "bac": {NAME: "charged_energy", FACTOR: 0.001},  # 12286143 Wh
         "bad": {NAME: "discharged_energy", FACTOR: 0.001},  # 8033557 Wh
+    },
+}
+
+# 0502 reuses some keys of the shared PP json structure with different meaning,
+# therefore override those mappings to avoid value flapping in merged device data
+_PP_JSON_0502 = _PP_JSON | {
+    "data": _PP_JSON["data"]
+    | {
+        "ws": {NAME: "wifi_signal"},  # Wi-Fi signal quality in %, e.g. 76 (verified against router), run status in 0500/0505
+        "90s": {NAME: "message_count?"},  # incrementing counter per 0502 message, pps_count in 0500/0505
     },
 }
 
@@ -5819,7 +5851,7 @@ SOLIXMQTTMAP: Final[dict] = {
         },
         "0502": {
             "a2": {
-                "json": _PP_JSON,
+                "json": _PP_JSON_0502,
             }
         },
         "0503": {


### PR DESCRIPTION
Corrections and additions to the A17B1 Power Panel `_PP_JSON` MQTT mappings, validated against my live system (A17B1 + 2x F3800) with controlled tests: App mode switches, Reserved for Outage changes, scheduled manual backup plans, installation method changes, and a 90 s main breaker pull.

**Full timestamped evidence for every change is posted in discussion thomluther/ha-anker-solix#447.**

Summary:
- `bs`: actual scheme is 1=standby, 2=charging, 3=discharging; 0 was never observed - deep sleep stops the 0500 telemetry stream instead (this is also the root cause of the HA battery_status sensor mismatch)
- `gs`: 0=on-grid, 1=grid outage (previous comment was inverted; verified by breaker test)
- `cp`: is the Reserved for Outage SOC setting, renamed to `backup_reserve`
- `dps`/`dpp` confirmed as backup plan status and scheduled plan slot; new `dpct` = charging_time estimate (same value as the HTTP field)
- `inmt`: installation method enum for 3rd-party PV wiring (0/1/2)
- `tgp`/`tlp` identified as cumulative energy counters
- new observed keys mapped: `scfg`, `tv`, `acc`, `90aacc`/`90bacc`, `b1e`, `tu`, `ep`/`os`/`ts` (constant 0, not outage related), `b1s`, `fe`, `status`/`code` (grid outage event message, code 105 observed)
- 0502 reuses `ws`/`90s` keys with different meaning (Wi-Fi signal % and a message counter), added a `_PP_JSON_0502` override to avoid value flapping in merged device data

Uncertain mappings keep the `?` suffix. Happy to adjust naming or restructure if you prefer a different approach.