### PR TITLE
feat(A1783): decode the C1000/C2000 G2 c490 protobuf device-summary

### DIFF
--- a/src/anker_solix_api/apitypes.py
+++ b/src/anker_solix_api/apitypes.py
@@ -2313,5 +2313,10 @@ class DeviceHexDataTypes(Enum):
     # The optional LENGTH with int for byte count can be specified (default is 0 if no base type used),
     # where Length of 0 indicates that first byte contains variable field length, e.g. for str type
     strb = bytes.fromhex("06")
+    # 07 is a LEB128 protobuf(-like) blob (e.g. the A1783 c490 device-summary "a2" field).
+    # It is walked to protobuf .path -> value and mapped via a BYTES submap whose keys are
+    # walker .paths. Self-delimiting varints make it width-drift proof, unlike the fixed
+    # base types above which misread multi-byte varints and >=128 leaf values.
+    varint = bytes.fromhex("07")
     json = bytes.fromhex("FE")  # virtual type to mark json in string types
     unk = bytes.fromhex("FF")  # unkonwn marker

--- a/src/anker_solix_api/apitypes.py
+++ b/src/anker_solix_api/apitypes.py
@@ -2314,7 +2314,7 @@ class DeviceHexDataTypes(Enum):
     # where Length of 0 indicates that first byte contains variable field length, e.g. for str type
     strb = bytes.fromhex("06")
     # FD is a virtual type to mark a LEB128 protobuf(-like) blob (e.g. the A1783 c490
-    # device-summary "a2" field). It is walked to protobuf .path -> value and mapped via a
+    # state-post "a2" field). It is walked to protobuf .path -> value and mapped via a
     # BYTES submap whose keys are walker .paths. Self-delimiting varints make it width-drift
     # proof, unlike the fixed base types above which misread multi-byte varints and >=128
     # leaf values.

--- a/src/anker_solix_api/apitypes.py
+++ b/src/anker_solix_api/apitypes.py
@@ -2313,10 +2313,11 @@ class DeviceHexDataTypes(Enum):
     # The optional LENGTH with int for byte count can be specified (default is 0 if no base type used),
     # where Length of 0 indicates that first byte contains variable field length, e.g. for str type
     strb = bytes.fromhex("06")
-    # 07 is a LEB128 protobuf(-like) blob (e.g. the A1783 c490 device-summary "a2" field).
-    # It is walked to protobuf .path -> value and mapped via a BYTES submap whose keys are
-    # walker .paths. Self-delimiting varints make it width-drift proof, unlike the fixed
-    # base types above which misread multi-byte varints and >=128 leaf values.
-    varint = bytes.fromhex("07")
+    # FD is a virtual type to mark a LEB128 protobuf(-like) blob (e.g. the A1783 c490
+    # device-summary "a2" field). It is walked to protobuf .path -> value and mapped via a
+    # BYTES submap whose keys are walker .paths. Self-delimiting varints make it width-drift
+    # proof, unlike the fixed base types above which misread multi-byte varints and >=128
+    # leaf values.
+    prtb = bytes.fromhex("FD")
     json = bytes.fromhex("FE")  # virtual type to mark json in string types
     unk = bytes.fromhex("FF")  # unkonwn marker

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -967,6 +967,146 @@ _A1783_0421 = {
     "fe": {NAME: "msg_timestamp"},
 }
 
+# c490 device-summary "a2" protobuf field map: walker .path -> field description.
+# a2 is a LEB128 protobuf(-like) rollup the A1783 (C1000/C2000 G2) posts on its own every
+# ~9 min over BLE; the ".23" sub-message is the live telemetry, the ".14"/".19" blocks are
+# cumulative lifetime energy ledgers split by direction AND source (a category 0421 lacks).
+# Paths + names confirmed live on a C2000 G2, cross-validated against VM per-port metrics
+# and the app's own field vocabulary (SOC/output/input/remaining_time/flow match 0421).
+# All a2 leaf fields (walker .path -> field). Confirmed names are unsuffixed; "?" marks
+# single-regime candidates and unknown/unmapped fields -- kept even when they read zero on a
+# base unit, since (like exp_1_*) they are conditional and light up under the right regime.
+# ".23" is the live rollup; ".14"/".19" are cumulative lifetime energy ledgers (by direction
+# + source); ".15" holds pack voltage/capacity/cycles; ".1"/".14.1" are string/bytes leaves.
+_A1783_0490_a2 = {
+    ".1": {NAME: "device_family_model"},  # C1000 G2 family model string
+    ".2": {NAME: "unknown_2?"},  # tbd
+    ".6.7": {NAME: "unknown_6_7?"},  # tbd
+    ".6.8": {NAME: "unknown_6_8?"},  # tbd
+    ".14.1": {NAME: "pack_bms_struct?"},  # main-pack BMS struct (bytes)
+    ".14.2": {NAME: "unknown_14_2?"},  # tbd
+    ".14.3": {NAME: "cumulative_charge_14_3"},  # charge-driven counter; coarse
+    ".14.4": {NAME: "cumulative_discharge_14_4"},  # discharge-driven counter; coarse
+    ".14.5": {NAME: "unknown_14_5?"},  # tbd
+    ".14.6": {NAME: "unknown_14_6?"},  # tbd
+    ".14#1.1": {NAME: "exp_1_bms_struct?"},  # expansion slot
+    ".14#1.2": {NAME: "exp_1_unknown_14_2?"},  # expansion slot
+    ".14#1.3": {NAME: "exp_1_cumulative_charge_14_3?"},  # expansion slot
+    ".14#1.4": {NAME: "exp_1_cumulative_discharge_14_4?"},  # expansion slot
+    ".14#1.5": {NAME: "exp_1_unknown_14_5?"},  # expansion slot
+    ".14#1.6": {NAME: "exp_1_unknown_14_6?"},  # expansion slot
+    ".15.1": {NAME: "battery_capacity_wh?"},  # usable capacity? (nominal 2048 Wh)
+    ".15.2": {NAME: "unknown_15_2?"},  # tbd
+    ".15.3": {NAME: "battery_voltage", FACTOR: 0.1},  # decivolts; not in 0421
+    ".15.4": {NAME: "battery_voltage_15_4?", FACTOR: 0.1},  # mirrors .15.3 pack voltage
+    ".15.5": {NAME: "unknown_15_5?"},  # state latch?
+    ".15.6": {NAME: "battery_cycles?"},  # cycle count?
+    ".15.7": {NAME: "unknown_15_7?"},  # tbd
+    ".15.8": {NAME: "unknown_15_8?"},  # tbd
+    ".15.9": {NAME: "unknown_15_9?"},  # tbd
+    ".15.10": {NAME: "unknown_15_10?"},  # tbd
+    ".15.11": {NAME: "unknown_15_11?"},  # tbd
+    ".15.12": {NAME: "unknown_15_12?"},  # tbd
+    ".15#1.1": {NAME: "exp_1_battery_capacity_wh?"},  # expansion slot
+    ".15#1.2": {NAME: "exp_1_unknown_15_2?"},  # expansion slot
+    ".15#1.3": {NAME: "exp_1_battery_voltage?", FACTOR: 0.1},  # expansion slot
+    ".15#1.4": {NAME: "exp_1_unknown_15_4?"},  # expansion slot
+    ".15#1.5": {NAME: "exp_1_unknown_15_5?"},  # expansion slot
+    ".15#1.6": {NAME: "exp_1_battery_cycles?"},  # expansion slot
+    ".15#1.7": {NAME: "exp_1_unknown_15_7?"},  # expansion slot
+    ".15#1.8": {NAME: "exp_1_unknown_15_8?"},  # expansion slot
+    ".15#1.9": {NAME: "exp_1_unknown_15_9?"},  # expansion slot
+    ".15#1.10": {NAME: "exp_1_unknown_15_10?"},  # expansion slot
+    ".15#1.11": {NAME: "exp_1_unknown_15_11?"},  # expansion slot
+    ".15#1.12": {NAME: "exp_1_unknown_15_12?"},  # expansion slot
+    ".18.1": {NAME: "unknown_18_1?"},  # tbd
+    ".18.2": {NAME: "unknown_18_2?"},  # tbd
+    ".18.3": {NAME: "unknown_18_3?"},  # tbd
+    ".18.4": {NAME: "unknown_18_4?"},  # tbd
+    ".18.5": {NAME: "unknown_18_5?"},  # tbd
+    ".18.6": {NAME: "unknown_18_6?"},  # tbd
+    ".18.7": {NAME: "unknown_18_7?"},  # tbd
+    ".18.8": {NAME: "unknown_18_8?"},  # tbd
+    ".19.1": {NAME: "cumulative_discharge_19_1"},  # discharge-driven
+    ".19.2": {NAME: "cumulative_ac_charge_19_2"},  # AC-charge-driven; coarse
+    ".19.3": {NAME: "cumulative_ac_charge_energy_wh"},  # AC-charge energy (Wh)
+    ".19.4": {NAME: "cumulative_ac_discharge_energy"},  # AC-output discharge; unit tbd
+    ".19.5": {NAME: "post_counter_19_5?"},  # post counter, paired with .22
+    ".19.6": {NAME: "cumulative_dc_charge_19_6"},  # DC/solar-charge-driven
+    ".19.7": {NAME: "cumulative_dc_charge_energy"},  # DC/solar charge; unit tbd
+    ".19.8": {NAME: "cumulative_discharge_energy_wh"},  # discharge energy (Wh)
+    ".20.1": {NAME: "unknown_20_1?"},  # tbd
+    ".20.2": {NAME: "unknown_20_2?"},  # tbd
+    ".20.3": {NAME: "unknown_20_3?"},  # tbd
+    ".20.4": {NAME: "unknown_20_4?"},  # tbd
+    ".20.5": {NAME: "unknown_20_5?"},  # tbd
+    ".20.6": {NAME: "unknown_20_6?"},  # tbd
+    ".20.7": {NAME: "unknown_20_7?"},  # tbd
+    ".20.8": {NAME: "unknown_20_8?"},  # tbd
+    ".20.9": {NAME: "unknown_20_9?"},  # tbd
+    ".21.1": {NAME: "unknown_21_1?"},  # tbd
+    ".21.2": {NAME: "unknown_21_2?"},  # tbd
+    ".21.3": {NAME: "unknown_21_3?"},  # tbd
+    ".21.4": {NAME: "unknown_21_4?"},  # tbd
+    ".21.5": {NAME: "unknown_21_5?"},  # tbd
+    ".21.6": {NAME: "unknown_21_6?"},  # tbd
+    ".21.7": {NAME: "unknown_21_7?"},  # tbd
+    ".21.8": {NAME: "unknown_21_8?"},  # tbd
+    ".21.9": {NAME: "unknown_21_9?"},  # tbd
+    ".22": {NAME: "post_counter?"},  # +1 per device post
+    ".23.1": {NAME: "battery_soc"},
+    ".23.1#1": {NAME: "exp_1_soc"},  # expansion battery SoC (slot 1)
+    ".23.2": {NAME: "output_power_total"},  # total output; DC/USB out = .23.2 - .23.3
+    ".23.3": {NAME: "ac_output_power"},  # AC output
+    ".23.4": {NAME: "input_power_total"},  # total input; AC in = .23.4 - .23.5
+    ".23.5": {NAME: "dc_input_power_total"},  # DC/solar input
+    ".23.6": {NAME: "charge_presence"},  # responds to DC input; unit tbd
+    ".23.7": {NAME: "work_status"},  # app: workStatus -- 0 idle / 1 discharge / 2 charge
+    ".23.8": {NAME: "remaining_time_hours", FACTOR: 0.1},  # deci-hours, bidirectional
+    ".23.9": {NAME: "unknown_23_9?"},  # tbd
+    ".23.10": {NAME: "unknown_23_10?"},  # tbd
+    ".24.1": {NAME: "unknown_24_1?"},  # config/mode flag?
+    ".24.2": {NAME: "unknown_24_2?"},  # tbd
+    ".24.3": {NAME: "unknown_24_3?"},  # tbd
+    ".24.4": {NAME: "unknown_24_4?"},  # tbd
+    ".24.5": {NAME: "unknown_24_5?"},  # tbd
+    ".24.6": {NAME: "unknown_24_6?"},  # tbd
+    ".24.7": {NAME: "unknown_24_7?"},  # tbd
+    ".24.8": {NAME: "unknown_24_8?"},  # tbd
+    ".24.9": {NAME: "unknown_24_9?"},  # tbd
+    ".24.10": {NAME: "unknown_24_10?"},  # tbd
+    ".24.11": {NAME: "unknown_24_11?"},  # tbd
+    ".24.12": {NAME: "unknown_24_12?"},  # tbd
+    ".24.13": {NAME: "unknown_24_13?"},  # tbd
+    ".24.14": {NAME: "unknown_24_14?"},  # tbd
+    ".24.15": {NAME: "unknown_24_15?"},  # tbd
+    ".24.16": {NAME: "unknown_24_16?"},  # tbd
+    ".24.17": {NAME: "unknown_24_17?"},  # tbd
+    ".24.18": {NAME: "unknown_24_18?"},  # tbd
+}
+
+_A1783_0490 = {
+    # C1000/C2000 G2 (A1783) periodic device-summary posted over BLE. Absent over MQTT.
+    "a1": {NAME: "summary_generation?"},  # 1 byte, const 0x31 -- family generation marker
+    "a2": {
+        # LEB128 protobuf rollup; walked and mapped via _A1783_0490_a2 (keys are walker paths)
+        TYPE: DeviceHexDataTypes.varint.value,
+        BYTES: _A1783_0490_a2,
+    },
+    "a3": {NAME: "charging_series_id", TYPE: DeviceHexDataTypes.str.value},
+}
+
+# C1000 G2 (A1763): same c490 frame, but the C1000 G2 has no BP2000 expansion option, so the
+# repeated per-pack fields (the "#" occurrence -- slot 1) never appear. Reuse the A1783 map
+# dropping every "#" path. Unverified on A1763 hardware; the payload embeds the A1763 model.
+_A1763_0490_a2 = {
+    path: desc for path, desc in _A1783_0490_a2.items() if "#" not in path
+}
+_A1763_0490 = {
+    **_A1783_0490,
+    "a2": {**_A1783_0490["a2"], BYTES: _A1763_0490_a2},
+}
+
 _A1780_0405 = {
     # F2000(P) param info
     TOPIC: "param_info",
@@ -5640,6 +5780,10 @@ SOLIXMQTTMAP: Final[dict] = {
         },
         # Interval: Irregular, maybe on changes or as response to App status request? Same content as 0421
         "0900": _A1763_0421,
+        # Interval: ~9 min, device-posted device summary over BLE only. Same frame format as
+        # the C2000 G2 (A1783), minus the exp_1_* fields (the C1000 G2 has no BP2000 option).
+        # Unverified on A1763 hardware; the c490 payload embeds the A1763 family model.
+        "0490": _A1763_0490,
     },
     # PPS C2000 Gen 2
     "A1783": {
@@ -5785,6 +5929,9 @@ SOLIXMQTTMAP: Final[dict] = {
         "0830": _PPS_VERSIONS_0830,
         # Interval: Irregular, maybe on changes or as response to App status request? Same content as 0421
         "0900": _A1783_0421,
+        # Interval: ~9 min, device-posted device summary over BLE only (absent over MQTT).
+        # a2 is a LEB128 protobuf rollup with cumulative energy ledgers 0421 does not carry.
+        "0490": _A1783_0490,
     },
     # PPS S2000 - matches A1783 (C2000 Gen 2); 0101-0103 controls inherited, not yet validated
     "AS220": {

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -991,10 +991,14 @@ _A1783_0421 = {
     "fe": {NAME: "msg_timestamp"},
 }
 
-# c490 device-summary "a2" protobuf field map: walker .path -> field description.
-# a2 is a LEB128 protobuf(-like) rollup the A1783 (C1000/C2000 G2) posts on its own every
-# ~9 min over BLE; the ".23" sub-message is the live telemetry, the ".14"/".19" blocks are
-# cumulative lifetime energy ledgers split by direction AND source (a category 0421 lacks).
+# c490 state-post "a2" protobuf field map: walker .path -> field description.
+# a2 is a LEB128 protobuf(-like) body the A1783 (C1000/C2000 G2) posts on its own every
+# ~9 min over BLE. It is NOT a summary or rollup of the 0421 stream -- it is an independent,
+# wider slice of live device state (115 leaves across 12 groups against 0421's 22 TLV tags,
+# including repeated groups 0421 never sends), sampled at post time. Values are therefore
+# instantaneous readings rather than anything averaged across the posting interval. The
+# ".23" sub-message is the live telemetry; the ".14"/".19" blocks are cumulative lifetime
+# energy ledgers split by direction AND source (a category 0421 lacks).
 # Paths + names confirmed live on a C2000 G2, cross-validated against VM per-port metrics
 # and the app's own field vocabulary (SOC/output/input/remaining_time/flow match 0421).
 # All a2 leaf fields (walker .path -> field). Confirmed names are unsuffixed; "?" marks
@@ -1122,7 +1126,8 @@ _A1783_0490_a2 = {
 }
 
 _A1783_0490 = {
-    # C1000/C2000 G2 (A1783) periodic device-summary posted over BLE. Absent over MQTT.
+    # C1000/C2000 G2 (A1783) periodic state post over BLE -- a distinct, wider slice of live
+    # device state rather than a rollup of 0421. Absent over MQTT.
     "a1": {
         NAME: "summary_generation?"
     },  # 1 byte, const 0x31 -- family generation marker

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -1090,7 +1090,7 @@ _A1783_0490 = {
     "a1": {NAME: "summary_generation?"},  # 1 byte, const 0x31 -- family generation marker
     "a2": {
         # LEB128 protobuf rollup; walked and mapped via _A1783_0490_a2 (keys are walker paths)
-        TYPE: DeviceHexDataTypes.varint.value,
+        TYPE: DeviceHexDataTypes.prtb.value,
         BYTES: _A1783_0490_a2,
     },
     "a3": {NAME: "charging_series_id", TYPE: DeviceHexDataTypes.str.value},

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -80,7 +80,6 @@ from .mqttcmdmap import (
     CMD_STATUS_REQUEST,
     CMD_SWIPE_DOWN_MODE,
     CMD_SWIPE_UP_MODE,
-    CMD_TBD_SWITCH,
     CMD_TEMP_UNIT,
     CMD_TEMP_UNIT_V2,
     CMD_TIMER_REQUEST,
@@ -672,7 +671,12 @@ _A1783_0421 = {
     "a3": {
         BYTES: {
             "00": {
-                NAME: "charging_status",  # (0-3): Inactive (0), DC Input (1), AC Input (2), Both (3)
+                # Battery status: Inactive (0), Discharging (1), Charging (2) -- the app
+                # calls it workStatus and also emits 5 (standby/sleep), so do not treat the
+                # set as closed. Same quantity as 0490 .23.7. NOT the source enum this
+                # entry used to document: value 1 occurs with zero input power, and
+                # simultaneous AC+DC input never produces 3.
+                NAME: "battery_status",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "04": {
@@ -763,7 +767,21 @@ _A1783_0421 = {
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "01": {
-                NAME: "charging_status_a5_1",  # (0-3): mirrors a3
+                # Same tri-state as a3.00 battery_status but tripping far earlier, not a
+                # mirror. Measured against a6.00 output_power_total over 48214 frames:
+                # this field is 0 if and only if output is exactly 0 W (23705 frames, no
+                # exceptions) and reads active from 1 W, whereas a3.00 needs roughly 11 W
+                # and lags. So a5.01 answers "is any current moving" and a3.00 "is the
+                # unit doing real work". a3.00's exact trip rule is unresolved -- observed
+                # transitions rise at 11-17 W and fall at 11-16 W, which no threshold or
+                # trailing average separates, but that capture had a mechanically unstable
+                # load so the sampled wattage need not be what triggered the change. What
+                # is safe either way: a3.00 flickers near the boundary, so treat it as a
+                # coarse state, not an edge-accurate one.
+                # Likely the app's chargeDischargeStatus, which shows exactly this
+                # one-sided split against workStatus in app logs; name not asserted
+                # without a co-observation against an app property dump.
+                NAME: "charging_status_a5_1",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "02": {
@@ -793,7 +811,10 @@ _A1783_0421 = {
                 SIGNED: False,
             },
             "08": {
-                NAME: "main_battery_soc?",  # SOC of main battery only?
+                # Still unconfirmed as main-only: equal to a5.02 battery_soc in all 103172
+                # frames of a C2000 G2 corpus, but no expansion pack was attached for any
+                # of them (c0 exp_1_sn all zero), so the two readings stay indistinguishable.
+                NAME: "main_battery_soc?",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
         },
@@ -809,11 +830,14 @@ _A1783_0421 = {
                 TYPE: DeviceHexDataTypes.sile.value,
             },
             "03": {
-                NAME: "ac_input_power_switch",  # Off (0), On (1)
+                # app: acInputStatus -- AC input lead present (0/1), not a user switch and
+                # not "charging active": observed 1 for long stretches with ac_input_power
+                # at 0, and never 0 while AC input power flows.
+                NAME: "ac_input_status",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "04": {
-                NAME: "ac_input_power", # mirrors a6.02
+                NAME: "ac_input_power",  # mirrors a6.02
                 TYPE: DeviceHexDataTypes.sile.value,
             },
         }
@@ -995,7 +1019,9 @@ _A1783_0490_a2 = {
     ".14#1.4": {NAME: "exp_1_cumulative_discharge_14_4?"},  # expansion slot
     ".14#1.5": {NAME: "exp_1_unknown_14_5?"},  # expansion slot
     ".14#1.6": {NAME: "exp_1_unknown_14_6?"},  # expansion slot
-    ".15.1": {NAME: "battery_capacity_wh?"},  # usable capacity? (nominal 2048 Wh)
+    # usable capacity, 1922 Wh on the C2000 G2 (nominal 2048 Wh); held static across
+    # 2368 frames spanning a full 5-100% SoC sweep, and zeroes per-pack when a pack drops
+    ".15.1": {NAME: "battery_capacity_wh"},
     ".15.2": {NAME: "unknown_15_2?"},  # tbd
     ".15.3": {NAME: "battery_voltage", FACTOR: 0.1},  # decivolts; not in 0421
     ".15.4": {NAME: "battery_voltage_15_4?", FACTOR: 0.1},  # mirrors .15.3 pack voltage
@@ -1060,8 +1086,14 @@ _A1783_0490_a2 = {
     ".23.3": {NAME: "ac_output_power"},  # AC output
     ".23.4": {NAME: "input_power_total"},  # total input; AC in = .23.4 - .23.5
     ".23.5": {NAME: "dc_input_power_total"},  # DC/solar input
-    ".23.6": {NAME: "charge_presence"},  # responds to DC input; unit tbd
-    ".23.7": {NAME: "work_status"},  # app: workStatus -- 0 idle / 1 discharge / 2 charge
+    # Centivolts at the DC input -- it reads the attached source, so it is a measurement
+    # rather than the presence flag the name suggested: ~42 (0.4 V) is a floating input with
+    # nothing plugged in, 3733-4422 (37-44 V) is a 2x PS400 array, and an ES720 cig socket
+    # reads 1687 (16.87 V) open-circuit falling to 1499 (14.99 V) while delivering 125 W.
+    # The apparent anti-correlation with power is just source droop under current.
+    ".23.6": {NAME: "dc_input_voltage", FACTOR: 0.01},
+    # same quantity as 0421 a3.00; app calls it workStatus (and also emits 5)
+    ".23.7": {NAME: "battery_status"},  # 0 inactive / 1 discharging / 2 charging
     ".23.8": {NAME: "remaining_time_hours", FACTOR: 0.1},  # deci-hours, bidirectional
     ".23.9": {NAME: "unknown_23_9?"},  # tbd
     ".23.10": {NAME: "unknown_23_10?"},  # tbd
@@ -1087,7 +1119,9 @@ _A1783_0490_a2 = {
 
 _A1783_0490 = {
     # C1000/C2000 G2 (A1783) periodic device-summary posted over BLE. Absent over MQTT.
-    "a1": {NAME: "summary_generation?"},  # 1 byte, const 0x31 -- family generation marker
+    "a1": {
+        NAME: "summary_generation?"
+    },  # 1 byte, const 0x31 -- family generation marker
     "a2": {
         # LEB128 protobuf rollup; walked and mapped via _A1783_0490_a2 (keys are walker paths)
         TYPE: DeviceHexDataTypes.prtb.value,
@@ -4233,7 +4267,9 @@ _AS220_0421 = {
     "a3": {
         BYTES: {
             "00": {
-                NAME: "charging_status",  # (0-3): Inactive (0), DC Input (1), AC Input (2), Both (3)
+                # Matches upstream, which already names this battery_status on AS220.
+                # Inherited from the A1783 template; not re-validated on AS220 hardware.
+                NAME: "battery_status",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "04": {
@@ -4320,7 +4356,9 @@ _AS220_0421 = {
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "01": {
-                NAME: "charging_status_a5_1",  # (0-3): Mirrors a3
+                # Inherited from the A1783 template, where this is a superset of a3.00
+                # rather than a mirror of it. Not re-validated on AS220 hardware.
+                NAME: "charging_status_a5_1",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "02": {

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -1057,7 +1057,11 @@ _A1783_0490_a2 = {
     ".19.2": {NAME: "cumulative_ac_charge_19_2"},  # AC-charge-driven; coarse
     ".19.3": {NAME: "cumulative_ac_charge_energy_wh"},  # AC-charge energy (Wh)
     ".19.4": {NAME: "cumulative_ac_discharge_energy"},  # AC-output discharge; unit tbd
-    ".19.5": {NAME: "post_counter_19_5?"},  # post counter, paired with .22
+    # Correlates with posting but is not a second view of .22: it skips posts .22 counts
+    # (stationary ~4 h on 2026-07-21 while .22 ticked every 9 min) and moves independently
+    # across an outage (.22 +574 vs .19.5 +598 at the 2026-07-31 resumption), so the offset
+    # between them drifts rather than holding. Do not derive one from the other.
+    ".19.5": {NAME: "post_counter_19_5?"},
     ".19.6": {NAME: "cumulative_dc_charge_19_6"},  # DC/solar-charge-driven
     ".19.7": {NAME: "cumulative_dc_charge_energy"},  # DC/solar charge; unit tbd
     ".19.8": {NAME: "cumulative_discharge_energy_wh"},  # discharge energy (Wh)

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -672,10 +672,15 @@ _A1783_0421 = {
         BYTES: {
             "00": {
                 # Battery status: Inactive (0), Discharging (1), Charging (2) -- the app
-                # calls it workStatus and also emits 5 (standby/sleep), so do not treat the
-                # set as closed. Same quantity as 0490 .23.7. NOT the source enum this
-                # entry used to document: value 1 occurs with zero input power, and
-                # simultaneous AC+DC input never produces 3.
+                # calls it workStatus, and the decompiled APK carries a matching "PPS Work
+                # Status" enum (0 idle / 1 discharge / 2 charge / 3 sleep / 4 shutdown)
+                # that agrees with this decode on 0-2 from a source independent of
+                # upstream's SolixPpsBatteryStatus. Do NOT treat the set as closed: this
+                # device also emits 5, which that enum does not define. Same quantity as
+                # 0490 .23.7. NOT the source enum this entry used to document: value 1
+                # occurs with zero input power, and simultaneous AC+DC input never
+                # produces 3. Distinct from a5.01 charge_discharge_status, which is the
+                # same tri-state but trips on any flow rather than past a threshold.
                 NAME: "battery_status",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
@@ -778,10 +783,18 @@ _A1783_0421 = {
                 # load so the sampled wattage need not be what triggered the change. What
                 # is safe either way: a3.00 flickers near the boundary, so treat it as a
                 # coarse state, not an edge-accurate one.
-                # Likely the app's chargeDischargeStatus, which shows exactly this
-                # one-sided split against workStatus in app logs; name not asserted
-                # without a co-observation against an app property dump.
-                NAME: "charging_status_a5_1",
+                # CONFIRMED as the app's chargeDischargeStatus (2026-08-19). Co-observed
+                # against the app's own property dump, where workStatus and
+                # chargeDischargeStatus appear on the SAME log line, so the comparison
+                # carries no alignment error: 5977 samples, cross-tab
+                #     ws=0 cds=0 2131 | ws=0 cds=1 1216 | ws=0 cds=2   19
+                #     ws=1 cds=1 1375 | ws=2 cds=2 1221 | ws=5 cds=0    9
+                # Same tri-state, different sensitivity -- cds trips on any flow, a3.00
+                # needs a threshold: the 1216 ws=0/cds=1 rows have a median 1 W output and
+                # the 19 ws=0/cds=2 rows a median 42 W input, while the agreeing rows sit
+                # at 37 W out / 669 W in. All 1250 disagreements run that one direction.
+                # ws=2 <-> cds=2 is exact both ways, and workStatus alone emits 5 (sleep).
+                NAME: "charge_discharge_status",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "02": {
@@ -4365,9 +4378,11 @@ _AS220_0421 = {
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "01": {
-                # Inherited from the A1783 template, where this is a superset of a3.00
-                # rather than a mirror of it. Not re-validated on AS220 hardware.
-                NAME: "charging_status_a5_1",
+                # Inherited from the A1783 template, where this is the app's
+                # chargeDischargeStatus -- the same tri-state as a3.00 but tripping on any
+                # flow rather than past a threshold. Named consistently with the A1783 so
+                # one field does not carry two names; NOT re-validated on AS220 hardware.
+                NAME: "charge_discharge_status",
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             "02": {

--- a/src/anker_solix_api/mqtttypes.py
+++ b/src/anker_solix_api/mqtttypes.py
@@ -33,6 +33,92 @@ from .mqttcmdmap import (
 from .mqttmap import SOLIXMQTTMAP
 
 
+def _read_varint(buf: bytes, pos: int) -> tuple[int, int]:
+    """Read one LEB128 varint from buf at pos; return (value, next_pos)."""
+    result = shift = 0
+    while True:
+        byte = buf[pos]
+        result |= (byte & 0x7F) << shift
+        pos += 1
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+
+
+def _is_protobuf_message(sub: bytes) -> bool:
+    """True if sub parses cleanly as a protobuf message (so it is recursed into)."""
+    pos = 0
+    try:
+        while pos < len(sub):
+            tag, pos = _read_varint(sub, pos)
+            wire = tag & 7
+            if wire == 0:
+                _, pos = _read_varint(sub, pos)
+            elif wire == 2:
+                length, pos = _read_varint(sub, pos)
+                pos += length
+            elif wire == 5:
+                pos += 4
+            elif wire == 1:
+                pos += 8
+            else:
+                return False
+        return pos == len(sub)
+    except (IndexError, ValueError):
+        return False
+
+
+def walk_protobuf(buf: bytes, prefix: str = "", out: dict | None = None) -> dict:
+    """Flatten a protobuf(-like) blob to a ``.field.subfield`` -> int map.
+
+    Keeps repeated tags in wire order (occurrence index appended as ``#n``) and addresses
+    every field by ``.path``, so byte offsets never matter -- a leaf value crossing 128
+    grows its varint in place without shifting anything. Used for the varint field type
+    (the A1783 c490 device-summary), which the fixed-offset TLV types cannot decode.
+
+    Every field is recorded: a length-delimited sub-message is stored as its byte length
+    *and* recursed into (so the container and its leaves both appear), and a wire-type 3/4
+    group marker is stored as ``None`` and stops the walk. Silently dropping containers
+    under-counts the message, which is a wrong decode.
+    """
+    if out is None:
+        out = {}
+    pos = 0
+    seen: dict[int, int] = {}
+    while pos < len(buf):
+        try:
+            tag, pos = _read_varint(buf, pos)
+        except IndexError:
+            break
+        fnum, wire = tag >> 3, tag & 7
+        occ = seen.get(fnum, 0)
+        seen[fnum] = occ + 1
+        path = f"{prefix}.{fnum}" + (f"#{occ}" if occ else "")
+        if wire == 0:
+            out[path], pos = _read_varint(buf, pos)
+        elif wire == 2:
+            length, pos = _read_varint(buf, pos)
+            sub = buf[pos : pos + length]
+            pos += length
+            if length and _is_protobuf_message(sub) and any(sub):
+                out[path] = length  # container: record its length, then its fields
+                walk_protobuf(sub, path, out)
+            elif sub and all(32 <= b < 127 for b in sub):
+                out[path] = sub.decode("ascii")  # printable string leaf
+            else:
+                out[path] = sub.hex()  # bytes leaf (kept as hex)
+        elif wire == 5:
+            out[path] = int.from_bytes(buf[pos : pos + 4], "little")
+            pos += 4
+        elif wire == 1:
+            out[path] = int.from_bytes(buf[pos : pos + 8], "little")
+            pos += 8
+        else:
+            out[path] = None  # group marker (wire type 3/4): record and stop
+            break
+    return out
+
+
 @dataclass(order=True, kw_only=True)
 class DeviceHexDataHeader:
     """Dataclass to structure Solix device hex data headers as received from MQTT transmissions.
@@ -406,6 +492,7 @@ class DeviceHexDataField:
                     DeviceHexDataTypes.sile.value,
                     DeviceHexDataTypes.var.value,
                     DeviceHexDataTypes.bin.value,
+                    DeviceHexDataTypes.varint.value,
                 ]
                 else fieldtype
             )
@@ -669,6 +756,21 @@ class DeviceHexDataField:
                         fieldmap=fieldmap.get(DeviceHexDataTypes.json.name, {}),
                     )
                 )
+            case DeviceHexDataTypes.varint.value:
+                # LEB128 protobuf(-like) blob (e.g. the A1783 c490 device-summary a2 field).
+                # Walk it to protobuf .path -> value; the BYTES submap keys are walker .paths,
+                # each an optional FACTOR/SIGNED like the base types. Self-delimiting varints
+                # make this width-drift proof (a value crossing 128 grows the field in place).
+                paths = walk_protobuf(hexdata)
+                for path, desc in (fieldmap.get(BYTES) or {}).items():
+                    if path in paths and (name := desc.get(NAME)):
+                        value = paths[path]
+                        if (
+                            isinstance(value, int)
+                            and (factor := desc.get(FACTOR, 1)) != 1
+                        ):
+                            value = round_by_factor(value * factor, factor)
+                        values[name] = value
             case _:
                 # check if type provided in mapping and convert value accordingly
                 if (

--- a/src/anker_solix_api/mqtttypes.py
+++ b/src/anker_solix_api/mqtttypes.py
@@ -492,7 +492,7 @@ class DeviceHexDataField:
                     DeviceHexDataTypes.sile.value,
                     DeviceHexDataTypes.var.value,
                     DeviceHexDataTypes.bin.value,
-                    DeviceHexDataTypes.varint.value,
+                    DeviceHexDataTypes.prtb.value,
                 ]
                 else fieldtype
             )
@@ -756,7 +756,7 @@ class DeviceHexDataField:
                         fieldmap=fieldmap.get(DeviceHexDataTypes.json.name, {}),
                     )
                 )
-            case DeviceHexDataTypes.varint.value:
+            case DeviceHexDataTypes.prtb.value:
                 # LEB128 protobuf(-like) blob (e.g. the A1783 c490 device-summary a2 field).
                 # Walk it to protobuf .path -> value; the BYTES submap keys are walker .paths,
                 # each an optional FACTOR/SIGNED like the base types. Self-delimiting varints

--- a/src/anker_solix_api/mqtttypes.py
+++ b/src/anker_solix_api/mqtttypes.py
@@ -74,7 +74,7 @@ def walk_protobuf(buf: bytes, prefix: str = "", out: dict | None = None) -> dict
     Keeps repeated tags in wire order (occurrence index appended as ``#n``) and addresses
     every field by ``.path``, so byte offsets never matter -- a leaf value crossing 128
     grows its varint in place without shifting anything. Used for the varint field type
-    (the A1783 c490 device-summary), which the fixed-offset TLV types cannot decode.
+    (the A1783 c490 state post), which the fixed-offset TLV types cannot decode.
 
     Every field is recorded: a length-delimited sub-message is stored as its byte length
     *and* recursed into (so the container and its leaves both appear), and a wire-type 3/4
@@ -757,7 +757,7 @@ class DeviceHexDataField:
                     )
                 )
             case DeviceHexDataTypes.prtb.value:
-                # LEB128 protobuf(-like) blob (e.g. the A1783 c490 device-summary a2 field).
+                # LEB128 protobuf(-like) blob (e.g. the A1783 c490 state-post a2 field).
                 # Walk it to protobuf .path -> value; the BYTES submap keys are walker .paths,
                 # each an optional FACTOR/SIGNED like the base types. Self-delimiting varints
                 # make this width-drift proof (a value crossing 128 grows the field in place).


### PR DESCRIPTION
Pre-announced in #319. This is the A1783 half of that effort — the `c490` (msgtype `0490`) device-summary decode. The BLE-transport half is flip-dots/SolixBLE#45.

## What this adds

The A1783 (C1000 / C2000 G2) posts a periodic device-summary on `c490`. `DeviceHexData` already tokenizes the outer `a1`/`a2`/`a3` frame natively; the only gap is `a2` — an opaque `bin` whose content is a LEB128 protobuf blob the fixed-offset TLV types can't decode (2-byte varint tags for field numbers ≥16, and self-delimiting varint leaves whose byte width drifts frame-to-frame).

- **`apitypes.py`** — a first-class `varint` `DeviceHexDataType` (`07`) for a protobuf-carrying field.
- **`mqtttypes.py`** — a small protobuf walker (`walk_protobuf`) that unpacks the field into a `.path → value` map keyed like the existing `BYTES` submaps (each leaf takes the usual optional `FACTOR`/`SIGNED`). Self-delimiting varints make it width-drift-proof.
- **`mqttmap.py`** — `_A1783_0490` / `_A1763_0490` naming the leaves.

## Validation

Field map cross-checked against the app's own decode and VictoriaMetrics across four charge/discharge regimes, over a 288-frame corpus spanning every observed frame size (372 / 373 / 374 / 376). Representative frames (2 per work_status state, 2 per byte length, annotated with the width-driving leaves): https://gist.github.com/kb1ibt/0f46385bb2a679434a07bb1e115c1271

## Notes

- Scoped to A1783 only. The `_A1783_0421` a5/a7 charge-field names I pre-announced in #319 are dropped here — you named them yourself in `e0f3ad5`.
- Device-internal fields with no app-side name (pack voltage, cumulative energy counters) are named by me and don't all follow your conventions — rename however fits.
- Opening as draft.
