### PR TITLE
Add A1753 (Solix C800)

### DIFF
--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -4242,18 +4242,22 @@ SOLIXMQTTMAP: Final[dict] = {
         # Following commands re-used from A1761; the corresponding status fields in
         # 0405 were verified by toggling each control in the app on a real device.
         "0043": CMD_DC_OUTPUT_TIMEOUT_SEC,  # DC output timeout; status field a3 verified
-        "0044": CMD_AC_CHARGE_LIMIT
+        "0044": CMD_AC_CHARGE_LIMIT  # AC Recharge Limit options as offered by app slider
         | {
             "a2": {
                 **CMD_AC_CHARGE_LIMIT["a2"],
-                VALUE_MIN: 200,
-                VALUE_MAX: 750,
-                VALUE_STEP: 50,
+                VALUE_OPTIONS: [200, 300, 400, 500, 600, 700, 750],
             }
-        },  # observed on device: 200-750 W (status field d1); min/step TBC
+        },  # status field d1 verified with app changes 750/600/300/200
         "004a": CMD_AC_OUTPUT_SWITCH,  # status fields bb/d7 verified
         "004b": CMD_DC_OUTPUT_SWITCH,  # status fields cc/d8 verified
-        "004f": CMD_LIGHT_MODE,  # status field dc verified: Off (0) - High (3)
+        "004f": CMD_LIGHT_MODE  # status field dc verified: Off (0) - High (3), no blinking mode
+        | {
+            "a2": {
+                **CMD_LIGHT_MODE["a2"],
+                VALUE_OPTIONS: {"off": 0, "low": 1, "medium": 2, "high": 3},
+            },
+        },
         "0052": CMD_DISPLAY_SWITCH,  # status field de verified
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
         # Interval: ~3-5 seconds, but only with realtime trigger

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -389,6 +389,40 @@ _A1761_0405 = {
     "fe": {NAME: "msg_timestamp"},  # Message timestamp
 }
 
+_A1753_0405 = {
+    # PPS C800 (A1753) param info
+    # Field layout partly matches the C1000 (_A1761_0405). Only fields verified
+    # against real C800 MQTT dumps are mapped below; remaining fields (SOH,
+    # switches, modes) still need verification before being added.
+    TOPIC: "param_info",
+    "a2": {
+        NAME: "ac_output_timeout_seconds"
+    },  # Active AC output auto-off countdown in seconds (0 = disabled); set via cmd 0042, range 0-86400, step 300
+    "a3": {
+        NAME: "dc_output_timeout_seconds"
+    },  # Active DC output auto-off countdown in seconds (tentative, observed 0)
+    "a4": {
+        NAME: "remaining_time_hours",
+        FACTOR: 0.1,
+        SIGNED: False,
+    },  # Remaining runtime in hours (value * factor)
+    "a5": {NAME: "ac_input_power"},  # AC charging power to battery (W)
+    "a6": {NAME: "ac_output_power"},  # AC outlet output power (W)
+    "a7": {NAME: "usbc_1_power"},  # USB-C port 1 output power (W)
+    "a8": {NAME: "usbc_2_power"},  # USB-C port 2 output power (W)
+    "a9": {NAME: "usba_1_power"},  # USB-A port 1 output power (W)
+    "aa": {NAME: "usba_2_power"},  # USB-A port 2 output power (W)
+    "ae": {NAME: "dc_input_power"},  # DC input power (solar/car charging) (W)
+    "af": {NAME: "photovoltaic_power"},  # Solar input power (W)
+    "b0": {NAME: "output_power_total"},  # Combined AC + DC output power (W)
+    "bd": {NAME: "temperature", SIGNED: True},  # Main device temperature (°C)
+    "c1": {NAME: "main_battery_soc"},  # Main battery state of charge (%), verified on real device
+    "d0": {NAME: "device_sn"},  # Device serial number
+    "d1": {NAME: "ac_input_limit"},  # Max AC charge setting (W)
+    "da": {NAME: "ac_frequency"},  # AC frequency (Hz): 50 / 60
+    "fe": {NAME: "msg_timestamp"},  # Message timestamp
+}
+
 _A1763_0421 = {
     "a2": {
         BYTES: {
@@ -4193,6 +4227,17 @@ SOLIXMQTTMAP: Final[dict] = {
         "0401": _A1725_0401,  # Interval: Irregular, triggered on app/device actions
         "0405": _A1725_0405,  # Interval: ~3-5 seconds, but only with realtime trigger
         "0830": _PPS_VERSIONS_0830,  # Interval: Irregular, triggered on app actions, no fixed interval
+    },
+    # PPS C800
+    "A1753": {
+        # Standby timer = AC output auto-off timeout. Command field a2 (var), seconds,
+        # range 0-86400, step 300, 0 = disabled. Verified against a real C800 MQTT dump.
+        "0042": CMD_AC_OUTPUT_TIMEOUT_SEC,
+        "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        # Interval: ~3-5 seconds, but only with realtime trigger
+        "0405": _A1753_0405,
+        # Interval: Irregular, triggered on app actions, no fixed interval
+        "0830": _PPS_VERSIONS_0830,
     },
     # PPS C1000(X) + B1000 Extension
     "A1761": {

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -393,14 +393,14 @@ _A1753_0405 = {
     # PPS C800 (A1753) param info
     # Field layout partly matches the C1000 (_A1761_0405). Only fields verified
     # against real C800 MQTT dumps are mapped below; remaining fields (SOH,
-    # switches, modes) still need verification before being added.
+    # output modes, timeout settings) still need verification before being added.
     TOPIC: "param_info",
     "a2": {
         NAME: "ac_output_timeout_seconds"
     },  # Active AC output auto-off countdown in seconds (0 = disabled); set via cmd 0042, range 0-86400, step 300
     "a3": {
         NAME: "dc_output_timeout_seconds"
-    },  # Active DC output auto-off countdown in seconds (tentative, observed 0)
+    },  # Active DC output auto-off countdown in seconds (0 = disabled); verified via app timer changes
     "a4": {
         NAME: "remaining_time_hours",
         FACTOR: 0.1,
@@ -414,12 +414,18 @@ _A1753_0405 = {
     "aa": {NAME: "usba_2_power"},  # USB-A port 2 output power (W)
     "ae": {NAME: "dc_input_power"},  # DC input power (solar/car charging) (W)
     "af": {NAME: "photovoltaic_power"},  # Solar input power (W)
-    "b0": {NAME: "output_power_total"},  # Combined AC + DC output power (W)
+    "b0": {NAME: "output_power_total"},  # Combined AC + DC output power (W), includes LED lamp (1-3 W)
+    "bb": {NAME: "ac_output_status"},  # AC inverter: Off (0), On (1); mirrors switch state d7
     "bd": {NAME: "temperature", SIGNED: True},  # Main device temperature (°C)
     "c1": {NAME: "main_battery_soc"},  # Main battery state of charge (%), verified on real device
+    "cc": {NAME: "dc_12v_status"},  # 12V car socket: Off (0), On (1); mirrors switch state d8
     "d0": {NAME: "device_sn"},  # Device serial number
-    "d1": {NAME: "ac_input_limit"},  # Max AC charge setting (W)
+    "d1": {NAME: "ac_input_limit"},  # Max AC charge setting (W), verified 750/600/300/200
+    "d7": {NAME: "ac_output_power_switch"},  # Disabled (0) or Enabled (1)
+    "d8": {NAME: "dc_output_power_switch"},  # Disabled (0) or Enabled (1)
     "da": {NAME: "ac_frequency"},  # AC frequency (Hz): 50 / 60
+    "dc": {NAME: "light_mode"},  # LED bar: Off (0), Low (1), Medium (2), High (3)
+    "de": {NAME: "display_switch"},  # Off (0) or On (1)
     "fe": {NAME: "msg_timestamp"},  # Message timestamp
 }
 
@@ -4233,6 +4239,22 @@ SOLIXMQTTMAP: Final[dict] = {
         # Standby timer = AC output auto-off timeout. Command field a2 (var), seconds,
         # range 0-86400, step 300, 0 = disabled. Verified against a real C800 MQTT dump.
         "0042": CMD_AC_OUTPUT_TIMEOUT_SEC,
+        # Following commands re-used from A1761; the corresponding status fields in
+        # 0405 were verified by toggling each control in the app on a real device.
+        "0043": CMD_DC_OUTPUT_TIMEOUT_SEC,  # DC output timeout; status field a3 verified
+        "0044": CMD_AC_CHARGE_LIMIT
+        | {
+            "a2": {
+                **CMD_AC_CHARGE_LIMIT["a2"],
+                VALUE_MIN: 200,
+                VALUE_MAX: 750,
+                VALUE_STEP: 50,
+            }
+        },  # observed on device: 200-750 W (status field d1); min/step TBC
+        "004a": CMD_AC_OUTPUT_SWITCH,  # status fields bb/d7 verified
+        "004b": CMD_DC_OUTPUT_SWITCH,  # status fields cc/d8 verified
+        "004f": CMD_LIGHT_MODE,  # status field dc verified: Off (0) - High (3)
+        "0052": CMD_DISPLAY_SWITCH,  # status field de verified
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0405": _A1753_0405,


### PR DESCRIPTION
## Summary

This PR adds MQTT device map support for the **Solix PPS C800 (A1753)** to
`mqttmap.py`, enabling standby timer control and basic realtime sensors.

Related to Issue [#511](https://github.com/thomluther/ha-anker-solix/issues/511).

Disclaimer: This was done with the help of Claude Code.

### Added

- **Command `0042`** (`CMD_AC_OUTPUT_TIMEOUT_SEC`): sets the standby timer
  (AC output auto-off timeout). Field `a2` (var-length int, seconds),
  range 0–86400, step 300, `0` = disabled.
- **Command `0057`** (`CMD_REALTIME_TRIGGER`): realtime status trigger,
  works as on other PPS models (0405 messages every ~3–5 s).
- **Status message `0405`** (`param_info`, `_A1753_0405`): only fields
  verified against real device dumps are mapped:
  - `a2`/`a3`: AC/DC output auto-off countdown (s)
  - `a4`: remaining runtime (h, factor 0.1)
  - `a5`–`aa`: AC input/output and USB-C/USB-A port powers (W)
  - `ae`/`af`: DC/solar input power (W)
  - `b0`: total output power (W)
  - `bd`: device temperature (°C, signed)
  - `c1`: main battery SOC (%)
  - `d0`: device SN, `d1`: max AC charge setting (W), `da`: AC frequency (Hz)
- **Version message `0830`**: reuses the common `_PPS_VERSIONS_0830` map.

The field layout largely follows the C1000 (`_A1761_0405`). Unverified fields
(SOH, switches, modes, sub-battery values) were intentionally left unmapped.

## How it was verified

All values were reverse engineered with this library's own `mqtt_monitor.py`
against a real C800 (firmware-current, EU account):

- **Standby timer (`0042`, field `a2`)**: captured the hex dump while setting
  1 h / 2 h / 3 h / off in the official Anker app; the payload contained
  `a2 = 3600 / 7200 / 10800 / 0` seconds. A command generated by this library
  was byte-identical to the app command and successfully changed the timer on
  the device (change visible in the app afterwards).
- **Battery SOC (`c1`)**: during a charging session the device display went
  from 32 % to 33 %; field `c1` switched from `0x20` (32) to `0x21` (33) at
  the same time and showed no other values in the dump.
- **Temperature (`bd`)**, **AC input limit (`d1` = 750 W)**, **AC frequency
  (`da` = 50 Hz)**, and the **port power fields** were cross-checked for
  plausibility across an idle/discharge dump and a charging dump.

## Testing

- `python -m py_compile src/anker_solix_api/mqttmap.py` passes.
- `SOLIXMQTTMAP["A1753"]` imports and resolves correctly.
- Live-tested with `mqtt_monitor.py` (realtime trigger + timer control) on a
  real A1753.

I'll provide the MQTT dump or run further captures if needed.