### PR TITLE
C800 followups

### DIFF
--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -4301,7 +4301,7 @@ SOLIXMQTTMAP: Final[dict] = {
             "a2": {
                 **CMD_DC_12V_OUTPUT_MODE["a2"],
                 VALUE_OPTIONS: {"normal": 0, "smart": 1},
-                STATE_CONVERTER: lambda value, state: (
+                STATE_CONVERTER: lambda value, state, cache=None: (
                     {1: 2, 0: 1}.get(value, 2)
                     if value is not None
                     else {2: 1, 1: 0}.get(state, 0)
@@ -4313,7 +4313,7 @@ SOLIXMQTTMAP: Final[dict] = {
             "a2": {
                 **CMD_AC_OUTPUT_MODE["a2"],
                 VALUE_OPTIONS: {"normal": 0, "smart": 1},
-                STATE_CONVERTER: lambda value, state: (
+                STATE_CONVERTER: lambda value, state, cache=None: (
                     {1: 2, 0: 1}.get(value, 2)
                     if value is not None
                     else {2: 1, 1: 0}.get(state, 0)

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -411,7 +411,7 @@ _A1753_0405 = {
     # PPS C800 (A1753) param info
     # Field layout matches the C1000 (_A1761_0405). Settings fields d2, d3, d9,
     # dc, dd were verified against real C800 MQTT dumps via app/monitor control
-    # session; remaining fields (SOH, output modes in f8) still unverified.
+    # session; remaining fields (SOH, f8 output modes / fast-charge status) TBC.
     TOPIC: "param_info",
     "a2": {
         NAME: "ac_output_timeout_seconds"
@@ -4294,32 +4294,11 @@ SOLIXMQTTMAP: Final[dict] = {
         "0050": CMD_TEMP_UNIT,  # verified, status field dd: Celsius (0) or Fahrenheit (1)
         "0052": CMD_DISPLAY_SWITCH,  # status field de verified
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
-        # App traces on C800 show inverted mode values compared to A1761 description:
-        # Normal/energy saving Off (0), Smart/energy saving On (1)
-        "0076": CMD_DC_12V_OUTPUT_MODE
-        | {
-            "a2": {
-                **CMD_DC_12V_OUTPUT_MODE["a2"],
-                VALUE_OPTIONS: {"normal": 0, "smart": 1},
-                STATE_CONVERTER: lambda value, state, cache=None: (
-                    {1: 2, 0: 1}.get(value, 2)
-                    if value is not None
-                    else {2: 1, 1: 0}.get(state, 0)
-                ),  # Smart setting represented with state 2
-            },
-        },  # verified via app command trace (energy saving switch of car socket)
-        "0077": CMD_AC_OUTPUT_MODE
-        | {
-            "a2": {
-                **CMD_AC_OUTPUT_MODE["a2"],
-                VALUE_OPTIONS: {"normal": 0, "smart": 1},
-                STATE_CONVERTER: lambda value, state, cache=None: (
-                    {1: 2, 0: 1}.get(value, 2)
-                    if value is not None
-                    else {2: 1, 1: 0}.get(state, 0)
-                ),  # Smart setting represented with state 2
-            },
-        },  # verified via app command trace (AC output smart mode switch)
+        "005e": CMD_AC_FAST_CHARGE_SWITCH,  # Ultrafast charge switch; offered in app, status mapping TBC
+        # Both commands confirmed via app traces on a real C800. No custom
+        # VALUE_OPTIONS/STATE_CONVERTER: status byte mapping (likely f8) still TBC.
+        "0076": CMD_DC_12V_OUTPUT_MODE,  # Car socket energy-saving / smart mode
+        "0077": CMD_AC_OUTPUT_MODE,  # AC output smart mode
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0405": _A1753_0405,
         # Interval: varies, probably upon change

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -410,8 +410,7 @@ _A1761_0405 = {
 _A1753_0405 = {
     # PPS C800 (A1753) param info
     # Field layout matches the C1000 (_A1761_0405). Settings fields d2, d3, d9,
-    # dc, dd were verified against real C800 MQTT dumps via app/monitor control
-    # session; remaining fields (SOH, f8 output modes / fast-charge status) TBC.
+    # dc, dd and f8 output modes were verified against real C800 MQTT dumps.
     TOPIC: "param_info",
     "a2": {
         NAME: "ac_output_timeout_seconds"
@@ -473,6 +472,18 @@ _A1753_0405 = {
     "dc": {NAME: "light_mode"},  # LED bar, verified: Off (0), Low (1), Medium (2), High (3), SOS/Blinking (4)
     "de": {NAME: "display_switch"},  # Off (0) or On (1)
     "dd": {NAME: "temp_unit_fahrenheit"},  # verified: Celsius (0) or Fahrenheit (1)
+    "f8": {
+        BYTES: {
+            "00": {
+                NAME: "dc_12v_output_mode",  # Normal (1), Smart (2); verified via cmd 0076
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            "01": {
+                NAME: "ac_output_mode",  # Normal (1), Smart (2); verified via cmd 0077
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+        }
+    },
     "fd": {NAME: "exp_1_type"},  # Expansion battery type identifier
     "fe": {NAME: "msg_timestamp"},  # Message timestamp
 }
@@ -4295,10 +4306,32 @@ SOLIXMQTTMAP: Final[dict] = {
         "0052": CMD_DISPLAY_SWITCH,  # status field de verified
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
         "005e": CMD_AC_FAST_CHARGE_SWITCH,  # Ultrafast charge switch; offered in app, status mapping TBC
-        # Both commands confirmed via app traces on a real C800. No custom
-        # VALUE_OPTIONS/STATE_CONVERTER: status byte mapping (likely f8) still TBC.
-        "0076": CMD_DC_12V_OUTPUT_MODE,  # Car socket energy-saving / smart mode
-        "0077": CMD_AC_OUTPUT_MODE,  # AC output smart mode
+        # Status bytes in f8 match A1761 (Normal=1, Smart=2). App command values on
+        # C800 are inverted vs A1761 VALUE_OPTIONS (C800: Normal/Off=0, Smart/On=1).
+        "0076": CMD_DC_12V_OUTPUT_MODE
+        | {
+            "a2": {
+                **CMD_DC_12V_OUTPUT_MODE["a2"],
+                VALUE_OPTIONS: {"normal": 0, "smart": 1},
+                STATE_CONVERTER: lambda value, state, cache=None: (
+                    {1: 2, 0: 1}.get(value, 2)
+                    if value is not None
+                    else {2: 1, 1: 0}.get(state, 0)
+                ),  # Smart setting represented with state 2
+            },
+        },  # car socket energy-saving; status f8[00] verified
+        "0077": CMD_AC_OUTPUT_MODE
+        | {
+            "a2": {
+                **CMD_AC_OUTPUT_MODE["a2"],
+                VALUE_OPTIONS: {"normal": 0, "smart": 1},
+                STATE_CONVERTER: lambda value, state, cache=None: (
+                    {1: 2, 0: 1}.get(value, 2)
+                    if value is not None
+                    else {2: 1, 1: 0}.get(state, 0)
+                ),  # Smart setting represented with state 2
+            },
+        },  # AC output smart mode; status f8[01] verified
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0405": _A1753_0405,
         # Interval: varies, probably upon change

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -4269,6 +4269,7 @@ SOLIXMQTTMAP: Final[dict] = {
     },
     # PPS C800
     "A1753": {
+        "0040": CMD_STATUS_REQUEST,  # Device status request, to be verified (one time status messages 0405 etc)
         "0042": CMD_AC_OUTPUT_TIMEOUT_SEC,  # field a2, range 0-86400, step 300, 0 = disabled.
         "0043": CMD_DC_OUTPUT_TIMEOUT_SEC,  # field a2, range 0-86400, step 300, 0 = disabled.
         "0044": CMD_AC_CHARGE_LIMIT  # AC Recharge Limit options as offered by app slider

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -409,9 +409,9 @@ _A1761_0405 = {
 
 _A1753_0405 = {
     # PPS C800 (A1753) param info
-    # Field layout partly matches the C1000 (_A1761_0405). Only fields verified
-    # against real C800 MQTT dumps are mapped below; remaining fields (SOH,
-    # output modes, timeout settings) still need verification before being added.
+    # Field layout matches the C1000 (_A1761_0405). Settings fields d2, d3, d9,
+    # dc, dd were verified against real C800 MQTT dumps via app/monitor control
+    # session; remaining fields (SOH, output modes in f8) still unverified.
     TOPIC: "param_info",
     "a2": {
         NAME: "ac_output_timeout_seconds"
@@ -464,15 +464,15 @@ _A1753_0405 = {
     },  # Max AC charge setting (W), verified 750/600/300/200
     "d2": {
         NAME: "device_timeout_minutes"
-    },  # Device auto-off timeout (minutes): 0 (Never), 30, 60, 120, 240, 360, 720, 1440
-    "d3": {NAME: "display_timeout_seconds"},  # Options: 20, 30, 60, 300, 1800 seconds
+    },  # verified: 0 (Never), 30, 60, 120, 240, 360, 720, 1440
+    "d3": {NAME: "display_timeout_seconds"},  # verified: 20, 30, 60, 300, 1800 seconds
     "d7": {NAME: "ac_output_power_switch"},  # Disabled (0) or Enabled (1)
     "d8": {NAME: "dc_output_power_switch"},  # Disabled (0) or Enabled (1)
-    "d9": {NAME: "display_mode"},  # Brightness: Off (0), Low (1), Medium (2), High (3)
+    "d9": {NAME: "display_mode"},  # Brightness, verified: Low (1), Medium (2), High (3), no Off option on C800
     "da": {NAME: "ac_frequency"},  # AC frequency (Hz): 50 / 60
-    "dc": {NAME: "light_mode"},  # LED bar: Off (0), Low (1), Medium (2), High (3)
+    "dc": {NAME: "light_mode"},  # LED bar, verified: Off (0), Low (1), Medium (2), High (3), SOS/Blinking (4)
     "de": {NAME: "display_switch"},  # Off (0) or On (1)
-    "dd": {NAME: "temp_unit_fahrenheit"},  # Celsius (0) or Fahrenheit (1)
+    "dd": {NAME: "temp_unit_fahrenheit"},  # verified: Celsius (0) or Fahrenheit (1)
     "fd": {NAME: "exp_1_type"},  # Expansion battery type identifier
     "fe": {NAME: "msg_timestamp"},  # Message timestamp
 }
@@ -4269,7 +4269,7 @@ SOLIXMQTTMAP: Final[dict] = {
     },
     # PPS C800
     "A1753": {
-        "0040": CMD_STATUS_REQUEST,  # Device status request, to be verified (one time status messages 0405 etc)
+        "0040": CMD_STATUS_REQUEST,  # Device status request, verified: returns a single 0405 message, also used by the app
         "0042": CMD_AC_OUTPUT_TIMEOUT_SEC,  # field a2, range 0-86400, step 300, 0 = disabled.
         "0043": CMD_DC_OUTPUT_TIMEOUT_SEC,  # field a2, range 0-86400, step 300, 0 = disabled.
         "0044": CMD_AC_CHARGE_LIMIT  # AC Recharge Limit options as offered by app slider
@@ -4279,21 +4279,47 @@ SOLIXMQTTMAP: Final[dict] = {
                 VALUE_OPTIONS: [200, 300, 400, 500, 600, 700, 750],
             }
         },  # status field d1 verified with app changes 750/600/300/200
-        "0045": CMD_DEVICE_TIMEOUT_MIN,  # Options in minutes: 0 (Never), 30, 60, 120, 240, 360, 720, 1440
-        "0046": CMD_DISPLAY_TIMEOUT_SEC,  # Options in seconds: 20, 30, 60, 300, 1800 seconds
+        "0045": CMD_DEVICE_TIMEOUT_MIN,  # verified incl. all options, status field d2; app offers same options as A1761
+        "0046": CMD_DISPLAY_TIMEOUT_SEC,  # verified incl. options, status field d3; app offers same options as A1761
         "004a": CMD_AC_OUTPUT_SWITCH,  # status fields bb/d7 verified
         "004b": CMD_DC_OUTPUT_SWITCH,  # status fields cc/d8 verified
-        "004c": CMD_DISPLAY_MODE,  # Display brightness: Off (0), Low (1), Medium (2), High (3)
-        "004f": CMD_LIGHT_MODE  # status field dc verified: Off (0) - High (3), no blinking mode
+        "004c": CMD_DISPLAY_MODE  # verified, status field d9; app offers no Off option on C800
         | {
             "a2": {
-                **CMD_LIGHT_MODE["a2"],
-                VALUE_OPTIONS: {"off": 0, "low": 1, "medium": 2, "high": 3},
+                **CMD_DISPLAY_MODE["a2"],
+                VALUE_OPTIONS: {"low": 1, "medium": 2, "high": 3},
             },
         },
-        "0050": CMD_TEMP_UNIT,  # Temperature unit switch: Celsius (0) or Fahrenheit (1)
+        "004f": CMD_LIGHT_MODE,  # status field dc verified: 0-3 via light control, Blinking (4) via app SOS toggle
+        "0050": CMD_TEMP_UNIT,  # verified, status field dd: Celsius (0) or Fahrenheit (1)
         "0052": CMD_DISPLAY_SWITCH,  # status field de verified
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        # App traces on C800 show inverted mode values compared to A1761 description:
+        # Normal/energy saving Off (0), Smart/energy saving On (1)
+        "0076": CMD_DC_12V_OUTPUT_MODE
+        | {
+            "a2": {
+                **CMD_DC_12V_OUTPUT_MODE["a2"],
+                VALUE_OPTIONS: {"normal": 0, "smart": 1},
+                STATE_CONVERTER: lambda value, state: (
+                    {1: 2, 0: 1}.get(value, 2)
+                    if value is not None
+                    else {2: 1, 1: 0}.get(state, 0)
+                ),  # Smart setting represented with state 2
+            },
+        },  # verified via app command trace (energy saving switch of car socket)
+        "0077": CMD_AC_OUTPUT_MODE
+        | {
+            "a2": {
+                **CMD_AC_OUTPUT_MODE["a2"],
+                VALUE_OPTIONS: {"normal": 0, "smart": 1},
+                STATE_CONVERTER: lambda value, state: (
+                    {1: 2, 0: 1}.get(value, 2)
+                    if value is not None
+                    else {2: 1, 1: 0}.get(state, 0)
+                ),  # Smart setting represented with state 2
+            },
+        },  # verified via app command trace (AC output smart mode switch)
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0405": _A1753_0405,
         # Interval: varies, probably upon change

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -4306,32 +4306,12 @@ SOLIXMQTTMAP: Final[dict] = {
         "0052": CMD_DISPLAY_SWITCH,  # status field de verified
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
         "005e": CMD_AC_FAST_CHARGE_SWITCH,  # Ultrafast charge switch; offered in app, status mapping TBC
-        # Status bytes in f8 match A1761 (Normal=1, Smart=2). App command values on
-        # C800 are inverted vs A1761 VALUE_OPTIONS (C800: Normal/Off=0, Smart/On=1).
-        "0076": CMD_DC_12V_OUTPUT_MODE
-        | {
-            "a2": {
-                **CMD_DC_12V_OUTPUT_MODE["a2"],
-                VALUE_OPTIONS: {"normal": 0, "smart": 1},
-                STATE_CONVERTER: lambda value, state, cache=None: (
-                    {1: 2, 0: 1}.get(value, 2)
-                    if value is not None
-                    else {2: 1, 1: 0}.get(state, 0)
-                ),  # Smart setting represented with state 2
-            },
-        },  # car socket energy-saving; status f8[00] verified
-        "0077": CMD_AC_OUTPUT_MODE
-        | {
-            "a2": {
-                **CMD_AC_OUTPUT_MODE["a2"],
-                VALUE_OPTIONS: {"normal": 0, "smart": 1},
-                STATE_CONVERTER: lambda value, state, cache=None: (
-                    {1: 2, 0: 1}.get(value, 2)
-                    if value is not None
-                    else {2: 1, 1: 0}.get(state, 0)
-                ),  # Smart setting represented with state 2
-            },
-        },  # AC output smart mode; status f8[01] verified
+        # Commands confirmed via app traces. Status in f8 matches A1761 (Normal=1,
+        # Smart=2). Observed app command polarity on C800 differs from A1761
+        # VALUE_OPTIONS (C800: Normal/Off=0, Smart/On=1); no custom converter —
+        # leave shared CMD definitions until polarity is confirmed upstream.
+        "0076": CMD_DC_12V_OUTPUT_MODE,  # car socket energy-saving; status f8[00] verified
+        "0077": CMD_AC_OUTPUT_MODE,  # AC output smart mode; status f8[01] verified
         # Interval: ~3-5 seconds, but only with realtime trigger
         "0405": _A1753_0405,
         # Interval: varies, probably upon change


### PR DESCRIPTION
Follow-up to #325, addressing the review feedback with a live verification
session on a real C800 (monitor control mode + app actions captured on the
cmd topic):

- **0040 status request**: works, returns exactly one 0405 message and no
  other message type. The app also publishes 0040 (with 0030/0057/0830)
  when opened, so 0040 is the app's status request as well.
- **0045/0046 timeouts**: all A1761 options verified working incl. 1440 min;
  status fields d2/d3 confirmed.
- **004c display mode**: verified via status field d9, but the C800 offers
  no Off option, so VALUE_OPTIONS restricted to Low/Medium/High.
- **0050 temp unit**: verified (dd: 0=Celsius, 1=Fahrenheit).
- **004f light mode**: the app's SOS toggle sends value 4 (blinking), so the
  C800 supports the full option set; removed the earlier restriction.
- **0076/0077 output modes**: captured from app command traces. Note: the
  C800 app sends Off/Normal (0) and On/Smart (1), which is *inverted*
  compared to the A1761 description (smart 0 / normal 1) - might be worth
  re-checking on the C1000. Described with adjusted VALUE_OPTIONS and
  STATE_CONVERTER; the f8 status representation could not be confirmed
  since the toggles ended at their initial state.
- **005e fast charge**: untested, device currently has no AC outlet nearby;
  the app shows an ultrafast charging option below AC input. Will verify
  when possible.

Open observations: unknown app command 0030 (sent periodically while the app
is open, contains the account id), a single 0072 during WiFi reconfiguration
(a2=0, a3=180, a4=240), and status field b6 toggling between 0 and 509.
Monitor dump available if helpful.

Attached is the anonymized mqtt_monitor dump from this verification session
(commands on the cmd topic + 0405 responses). The real serial was replaced
with the same random serial as in the earlier system export zip
(N95DZBSC3AUFKUIB), so both can be correlated. Account id, client ids, the
WiFi password and scanned neighbor SSIDs were redacted.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3bb106c4-2e7f-4a59-80d8-22324e85b393" />


[c800_2026-07-31_anonymized.txt.zip](https://github.com/user-attachments/files/30602876/c800_2026-07-31_anonymized.txt.zip)