### PR TITLE
Add set_pps_use_time() + A1763 TOU read mapping + 005e backup charge …

### DIFF
--- a/src/anker_solix_api/api.py
+++ b/src/anker_solix_api/api.py
@@ -1179,6 +1179,9 @@ class AnkerSolixApi(AnkerSolixBaseApi):
                             device["display_theme"] = self.get_charger_themes(
                                 deviceSn=sn
                             ).get(str(value), {})
+                    # PPS TOU plan (pps_use_time): store the raw plan for PPS devices
+                    elif key == "pps_use_time":
+                        device[key] = value
                 except Exception:  # pylint: disable=broad-exception-caught
                     self._logger.exception(
                         "Api %s exception occurred when updating device details for key %s with value %s",

--- a/src/anker_solix_api/api.py
+++ b/src/anker_solix_api/api.py
@@ -85,6 +85,7 @@ class AnkerSolixApi(AnkerSolixBaseApi):
         set_device_load,
         set_device_parm,
         set_home_load,
+        set_pps_use_time,
         set_sb2_ac_charge,
         set_sb2_home_load,
         set_sb2_use_time,

--- a/src/anker_solix_api/mqttcmdmap.py
+++ b/src/anker_solix_api/mqttcmdmap.py
@@ -2426,6 +2426,16 @@ CMD_PPS_USAGE_MODE_V2 = CMD_COMMON_V2 | {
     },
 }
 
+# Usage mode restricted to Standard + Time-of-Use. The Anker app on the PPS
+# models that only offer TOU (A1763, A1783, A1785) errors on Self-Consumption
+# and Custom, so those options must not be offered for them.
+CMD_PPS_USAGE_MODE_TOU_ONLY = CMD_PPS_USAGE_MODE_V2 | {
+    "a2": {
+        **CMD_PPS_USAGE_MODE_V2["a2"],
+        VALUE_OPTIONS: {"standard": 0, "time_of_use": 1},
+    },
+}
+
 CMD_TOU_PLAN_V2 = CMD_PPS_USAGE_MODE_V2 | {
     # TOU plan for AS220, A1785, typically sent via cloud
     "a2": CMD_PPS_USAGE_MODE_V2["a2"]
@@ -2493,6 +2503,99 @@ CMD_PPS_BACKUP_SOC_V2 = CMD_COMMON_V2 | {
         VALUE_MAX_STATE: "max_soc",
     },
 }
+
+# PPS TOU 0090 command group: usage mode (a2) + backup SOC (a5).
+# The TOU plan itself is controlled via the cloud pps_use_time attribute
+# (set_pps_use_time), not via MQTT.
+CMD_PPS_TOU_0090 = {
+    COMMAND_LIST: [
+        SolixMqttCommands.pps_usage_mode,
+        SolixMqttCommands.backup_soc,
+    ],
+    SolixMqttCommands.pps_usage_mode: CMD_PPS_USAGE_MODE_V2,
+    SolixMqttCommands.backup_soc: CMD_PPS_BACKUP_SOC_V2,
+}
+
+# PPS TOU 0090 command group with the TOU-only usage-mode options
+# (Standard + Time-of-Use). Use for models whose app errors on
+# Self-Consumption/Custom (A1763, A1783, A1785); AS220 uses the full
+# CMD_PPS_USAGE_MODE_V2 options plus pps_tou_schedule.
+CMD_PPS_TOU_0090_TOU_ONLY = {
+    **CMD_PPS_TOU_0090,
+    SolixMqttCommands.pps_usage_mode: CMD_PPS_USAGE_MODE_TOU_ONLY,
+}
+
+# Shared PPS TOU d9 status BYTES list (A1763 / A1783 / AS220 / ...).
+# The d9 field is VARIABLE-LENGTH: the TOU schedule region is
+# (1 count byte + 3 bytes/slot x count), so all fields after the schedule shift
+# with the slot count (total = 25 + 3*count bytes). A sequential BYTES list is
+# required so the parser advances past the variable-length schedule.
+# Field names use the A1783 nomenclature; the A1763 d9 carries the same bytes
+# (active tariff, usage mode, backup reserve, max/min SOC) under shorter names.
+PPS_TOU_D9_BYTES = [
+    {
+        NAME: "active_tariff",  # TOUSystemStatus: 0=None (UPS), 1=Peak, 2=Mid Peak, 3=Off Peak (device-computed)
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "usage_mode",  # TOUSettingSystemStatus: 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "backup_soc",  # backup reserve % (app "TOU power"), step 1%, range [min_soc+5, max_soc]
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "backup_charge_soc",  # max SOC % (for tou and backup usage): 80, 85, 90, 95, 100
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "backup_discharge_soc",  # min SOC % (for backup discharge): 1, 5, 10, 15, 20
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "tou_mode_schedule",  # count byte + (tariff,start_hr,end_hr) x count; count byte INCLUDED
+        TYPE: DeviceHexDataTypes.bin.value,
+        # counted=True (default): the status schedule starts with a slot count byte
+        STATE_CONVERTER: lambda value, state, cache: (
+            convert_pps_tou_schedule(value)
+            if value is not None
+            else convert_pps_tou_schedule(state)
+        ),
+    },
+    {
+        NAME: "backup_status",  # 0: inactive, 1: planned charge, 2: storm guard charge
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "backup_switch",
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "storm_guard_switch",
+        TYPE: DeviceHexDataTypes.ui.value,
+    },
+    {
+        NAME: "backup_start_timestamp",
+        TYPE: DeviceHexDataTypes.var.value,
+        SIGNED: False,
+    },
+    {
+        NAME: "backup_end_timestamp",  # 0xffffffff = no end / ongoing
+        TYPE: DeviceHexDataTypes.var.value,
+        SIGNED: False,
+    },
+    {
+        NAME: "auto_backup_start_timestamp",
+        TYPE: DeviceHexDataTypes.var.value,
+        SIGNED: False,
+    },
+    {
+        NAME: "auto_backup_end_timestamp",
+        TYPE: DeviceHexDataTypes.var.value,
+        SIGNED: False,
+    },
+]
 
 CMD_TBD_SWITCH = CMD_COMMON | {
     # Command: Generic switch command with unknown effect

--- a/src/anker_solix_api/mqttcmdmap.py
+++ b/src/anker_solix_api/mqttcmdmap.py
@@ -2465,6 +2465,35 @@ CMD_TOU_PLAN_V2 = CMD_PPS_USAGE_MODE_V2 | {
     },
 }
 
+CMD_PPS_BACKUP_SOC_V2 = CMD_COMMON_V2 | {
+    # PPS backup SOC (reserve) setting, field a5
+    "a5": {
+        NAME: "set_backup_soc",  # range as [min_soc + 5, max_soc], step 1%
+        TYPE: DeviceHexDataTypes.ui.value,
+        STATE_NAME: "backup_soc",
+        VALUE_MIN: 5,
+        VALUE_MAX: 100,
+        VALUE_STEP: 1,
+        STATE_CONVERTER: lambda value, state, cache: (
+            value
+            if value is not None
+            # ensure backup is min + 5 < backup <= max if not specified
+            else min(
+                int(cache.get("max_soc") or 80),
+                max(
+                    int(cache.get("power_cutoff") or 20) + 5,
+                    int(state),
+                ),
+            )
+            if state is not None
+            and str(state).replace(".", "", 1).isdigit()
+            else None
+        ),
+        VALUE_MIN_STATE: "power_cutoff",
+        VALUE_MAX_STATE: "max_soc",
+    },
+}
+
 CMD_TBD_SWITCH = CMD_COMMON | {
     # Command: Generic switch command with unknown effect
     COMMAND_NAME: SolixMqttCommands.tbd_switch,

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -73,6 +73,7 @@ from .mqttcmdmap import (
     CMD_PORT_PRIORITY,
     CMD_PORT_START,
     CMD_PORT_TIMER,
+    CMD_PPS_BACKUP_SOC_V2,
     CMD_PPS_USAGE_MODE_V2,
     CMD_REALTIME_TRIGGER,
     CMD_REVERSE_CHARGE_LIMITS,
@@ -761,16 +762,74 @@ _A1763_0421 = {
         ]
     },
     "d9": {
-        BYTES: {
-            "03": {
+        # TOU system status + backup + Time-of-Use plan.
+        # VARIABLE-LENGTH field: the TOU schedule region is (1 count byte + 3 bytes/slot x count),
+        # so all fields after the schedule shift with the slot count (total = 25 + 3*count bytes).
+        # Use a sequential BYTES list so the parser advances past the variable-length schedule.
+        BYTES: [
+            {
+                NAME: "active_tariff",  # Active tariff at current time: 0=none (UPS), 1=Peak, 2=Mid, 3=Off (device-computed)
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            {
+                NAME: "usage_mode",  # TOUSettingSystemStatus: 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            {
+                NAME: "backup_soc",  # backup reserve % (app "TOU power"), step 1%, range [min_soc+5, max_soc]
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            {
                 NAME: "max_soc",  # max_soc: 80, 85, 90, 95, 100 %
                 TYPE: DeviceHexDataTypes.ui.value,
             },
-            "04": {
+            {
                 NAME: "min_soc",  # min_soc: 1, 5, 10, 15, 20 %
                 TYPE: DeviceHexDataTypes.ui.value,
             },
-        }
+            {
+                NAME: "tou_mode_schedule",  # count byte + (tariff,start_hr,end_hr) x count; count byte INCLUDED
+                TYPE: DeviceHexDataTypes.bin.value,
+                # counted=True (default): the status schedule starts with a slot count byte
+                STATE_CONVERTER: lambda value, state, cache: (
+                    convert_pps_tou_schedule(value)
+                    if value is not None
+                    else convert_pps_tou_schedule(state)
+                ),
+            },
+            {
+                NAME: "backup_status",  # 0: inactive, 1: planned charge, 2: storm guard charge
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            {
+                NAME: "backup_switch",
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            {
+                NAME: "storm_guard_switch",
+                TYPE: DeviceHexDataTypes.ui.value,
+            },
+            {
+                NAME: "backup_start_timestamp",
+                TYPE: DeviceHexDataTypes.var.value,
+                SIGNED: False,
+            },
+            {
+                NAME: "backup_end_timestamp",  # 0xffffffff = no end / ongoing
+                TYPE: DeviceHexDataTypes.var.value,
+                SIGNED: False,
+            },
+            {
+                NAME: "auto_backup_start_timestamp",
+                TYPE: DeviceHexDataTypes.var.value,
+                SIGNED: False,
+            },
+            {
+                NAME: "auto_backup_end_timestamp",
+                TYPE: DeviceHexDataTypes.var.value,
+                SIGNED: False,
+            },
+        ]
     },
     # "da": # Field used for screen schedule and theme settings, not supported on device
     "f9": {
@@ -4565,6 +4624,27 @@ SOLIXMQTTMAP: Final[dict] = {
     # PPS C1000 Gen 2
     "A1763": {
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages 0405 etc
+        "005e": {
+            # Backup charge plan command group
+            COMMAND_LIST: [
+                SolixMqttCommands.backup_charge_storm_guard,  # field a3, a4, a5
+                SolixMqttCommands.backup_charge_plan,  # field a3-a5
+                SolixMqttCommands.backup_charge_timestamps,  # field a6-a8
+            ],
+            SolixMqttCommands.backup_charge_storm_guard: CMD_BACKUP_STORM_GUARD_SWITCH_V2,
+            SolixMqttCommands.backup_charge_plan: CMD_BACKUP_SWITCH_V2,
+            SolixMqttCommands.backup_charge_timestamps: CMD_BACKUP_PLAN_TIMESTAMPS_V2,
+        },
+        "0090": {
+            # TOU command group; the TOU plan itself is controlled via
+            # the cloud pps_use_time attribute (set_pps_use_time), not via MQTT
+            COMMAND_LIST: [
+                SolixMqttCommands.pps_usage_mode,  # field a2
+                SolixMqttCommands.backup_soc,  # field a5
+            ],
+            SolixMqttCommands.pps_usage_mode: CMD_PPS_USAGE_MODE_V2,  # 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
+            SolixMqttCommands.backup_soc: CMD_PPS_BACKUP_SOC_V2,  # reserve [min_soc + 5, max_soc], step 1%
+        },
         "0101": {
             # AC command group
             COMMAND_LIST: [
@@ -5130,34 +5210,7 @@ SOLIXMQTTMAP: Final[dict] = {
                     },
                 },
             },
-            SolixMqttCommands.backup_soc: CMD_COMMON_V2
-            | {
-                "a5": {
-                    NAME: "set_backup_soc",  # range as [min_soc + 5, max_soc], step 1%
-                    TYPE: DeviceHexDataTypes.ui.value,
-                    STATE_NAME: "backup_soc",
-                    VALUE_MIN: 5,
-                    VALUE_MAX: 100,
-                    VALUE_STEP: 1,
-                    STATE_CONVERTER: lambda value, state, cache: (
-                        value
-                        if value is not None
-                        # ensure backup is min + 5 < backup <= max if not specified
-                        else min(
-                            int(cache.get("max_soc") or 80),
-                            max(
-                                int(cache.get("power_cutoff") or 20) + 5,
-                                int(state),
-                            ),
-                        )
-                        if state is not None
-                        and str(state).replace(".", "", 1).isdigit()
-                        else None
-                    ),
-                    VALUE_MIN_STATE: "power_cutoff",
-                    VALUE_MAX_STATE: "max_soc",
-                },
-            },
+            SolixMqttCommands.backup_soc: CMD_PPS_BACKUP_SOC_V2,
         },
         "0101": {
             # AC command group
@@ -5336,34 +5389,7 @@ SOLIXMQTTMAP: Final[dict] = {
             ],
             SolixMqttCommands.pps_usage_mode: CMD_PPS_USAGE_MODE_V2,  # 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
             SolixMqttCommands.pps_tou_schedule: CMD_TOU_PLAN_V2,
-            SolixMqttCommands.backup_soc: CMD_COMMON_V2
-            | {
-                "a5": {
-                    NAME: "set_backup_soc",  # range as [min_soc + 5, max_soc], step 1%
-                    TYPE: DeviceHexDataTypes.ui.value,
-                    STATE_NAME: "backup_soc",
-                    VALUE_MIN: 5,
-                    VALUE_MAX: 100,
-                    VALUE_STEP: 1,
-                    STATE_CONVERTER: lambda value, state, cache: (
-                        value
-                        if value is not None
-                        # ensure backup is min + 5 < backup <= max if not specified
-                        else min(
-                            int(cache.get("max_soc") or 80),
-                            max(
-                                int(cache.get("power_cutoff") or 20) + 5,
-                                int(state),
-                            ),
-                        )
-                        if state is not None
-                        and str(state).replace(".", "", 1).isdigit()
-                        else None
-                    ),
-                    VALUE_MIN_STATE: "power_cutoff",
-                    VALUE_MAX_STATE: "max_soc",
-                },
-            },
+            SolixMqttCommands.backup_soc: CMD_PPS_BACKUP_SOC_V2,
         },
         "0093": {
             COMMAND_LIST: [

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -74,6 +74,7 @@ from .mqttcmdmap import (
     CMD_PORT_START,
     CMD_PORT_TIMER,
     CMD_PPS_BACKUP_SOC_V2,
+    CMD_PPS_TOU_0090_TOU_ONLY,
     CMD_PPS_USAGE_MODE_V2,
     CMD_REALTIME_TRIGGER,
     CMD_REVERSE_CHARGE_LIMITS,
@@ -112,6 +113,7 @@ from .mqttcmdmap import (
     MASK,
     NAME,
     OFFSET,
+    PPS_TOU_D9_BYTES,
     SIGNED,
     STATE_CONVERTER,
     STATE_NAME,
@@ -763,73 +765,7 @@ _A1763_0421 = {
     },
     "d9": {
         # TOU system status + backup + Time-of-Use plan.
-        # VARIABLE-LENGTH field: the TOU schedule region is (1 count byte + 3 bytes/slot x count),
-        # so all fields after the schedule shift with the slot count (total = 25 + 3*count bytes).
-        # Use a sequential BYTES list so the parser advances past the variable-length schedule.
-        BYTES: [
-            {
-                NAME: "tou_active_tariff",  # Active tariff at current time: 0=none (UPS), 1=Peak, 2=Mid, 3=Off (device-computed)
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "usage_mode",  # TOUSettingSystemStatus: 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_soc",  # backup reserve % (app "TOU power"), step 1%, range [min_soc+5, max_soc]
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "max_soc",  # max_soc: 80, 85, 90, 95, 100 %
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "min_soc",  # min_soc: 1, 5, 10, 15, 20 %
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "tou_mode_schedule",  # count byte + (tariff,start_hr,end_hr) x count; count byte INCLUDED
-                TYPE: DeviceHexDataTypes.bin.value,
-                # counted=True (default): the status schedule starts with a slot count byte
-                STATE_CONVERTER: lambda value, state, cache: (
-                    convert_pps_tou_schedule(value)
-                    if value is not None
-                    else convert_pps_tou_schedule(state)
-                ),
-            },
-            {
-                NAME: "backup_status",  # 0: inactive, 1: planned charge, 2: storm guard charge
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_switch",
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "storm_guard_switch",
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_start_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-            {
-                NAME: "backup_end_timestamp",  # 0xffffffff = no end / ongoing
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-            {
-                NAME: "auto_backup_start_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-            {
-                NAME: "auto_backup_end_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-        ]
+        BYTES: PPS_TOU_D9_BYTES,
     },
     # "da": # Field used for screen schedule and theme settings, not supported on device
     "f9": {
@@ -1142,73 +1078,7 @@ _A1783_0421 = {
     },
     "d9": {
         # TOU mode selector + backup + Time-of-Use plan
-        BYTES: [
-            {
-                NAME: "active_tariff",  # TOUSystemStatus: 0=None, 1=Peak, 2=Mid Peak, 3=Off Peak
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "usage_mode",  # TOUSettingSystemStatus: 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_soc",  # backup reserve % (discharge floor for tou)
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_charge_soc",  # changed with max_soc % (for tou and backup usage)
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_discharge_soc",  # changed with min_soc % (for backup discharge?)
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            # Byte 5 is the tou schedule slot count and 6+ holds the TOU schedule:
-            # (tariff(1=Peak,2=Mid,3=Off), start_hr, end_hr) * tou_slot_count
-            # App allows max 6 slots, remainder of field has different purpose
-            {
-                NAME: "tou_mode_schedule",
-                TYPE: DeviceHexDataTypes.bin.value,
-                # Define both conversions since length of schedule is flexible within binary
-                STATE_CONVERTER: lambda value, state, cache: (
-                    convert_pps_tou_schedule(value)
-                    if value is not None
-                    else convert_pps_tou_schedule(state)
-                ),
-            },
-            {
-                NAME: "backup_status",  # 0: inactive, 1: planned charge: 2: storm guard charge
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_switch",
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "storm_guard_switch",
-                TYPE: DeviceHexDataTypes.ui.value,
-            },
-            {
-                NAME: "backup_start_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-            {
-                NAME: "backup_end_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-            {
-                NAME: "auto_backup_start_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-            {
-                NAME: "auto_backup_end_timestamp",
-                TYPE: DeviceHexDataTypes.var.value,
-                SIGNED: False,
-            },
-        ]
+        BYTES: PPS_TOU_D9_BYTES,
     },
     # "da" # Field used for screen schedule and theme settings
     "f9": {
@@ -4731,16 +4601,7 @@ SOLIXMQTTMAP: Final[dict] = {
             SolixMqttCommands.backup_charge_plan: CMD_BACKUP_SWITCH_V2,
             SolixMqttCommands.backup_charge_timestamps: CMD_BACKUP_PLAN_TIMESTAMPS_V2,
         },
-        "0090": {
-            # TOU command group; the TOU plan itself is controlled via
-            # the cloud pps_use_time attribute (set_pps_use_time), not via MQTT
-            COMMAND_LIST: [
-                SolixMqttCommands.pps_usage_mode,  # field a2
-                SolixMqttCommands.backup_soc,  # field a5
-            ],
-            SolixMqttCommands.pps_usage_mode: CMD_PPS_USAGE_MODE_V2,  # 0=Standard, 1=Time-of-Use, 2=Self-Consumption, 3=Custom
-            SolixMqttCommands.backup_soc: CMD_PPS_BACKUP_SOC_V2,  # reserve [min_soc + 5, max_soc], step 1%
-        },
+        "0090": CMD_PPS_TOU_0090_TOU_ONLY,  # A1763: app only supports Standard + Time-of-Use (Self-Consumption/Custom error); the TOU plan is cloud-controlled via pps_use_time
         "0101": {
             # AC command group
             COMMAND_LIST: [

--- a/src/anker_solix_api/mqttmap.py
+++ b/src/anker_solix_api/mqttmap.py
@@ -768,7 +768,7 @@ _A1763_0421 = {
         # Use a sequential BYTES list so the parser advances past the variable-length schedule.
         BYTES: [
             {
-                NAME: "active_tariff",  # Active tariff at current time: 0=none (UPS), 1=Peak, 2=Mid, 3=Off (device-computed)
+                NAME: "tou_active_tariff",  # Active tariff at current time: 0=none (UPS), 1=Peak, 2=Mid, 3=Off (device-computed)
                 TYPE: DeviceHexDataTypes.ui.value,
             },
             {

--- a/src/anker_solix_api/poller.py
+++ b/src/anker_solix_api/poller.py
@@ -18,6 +18,7 @@ from .apitypes import (
     SolixPriceProvider,
     SolixSiteType,
 )
+from .errors import AnkerSolixError
 from .hesapi import AnkerSolixHesApi
 from .powerpanel import AnkerSolixPowerpanelApi
 
@@ -1364,6 +1365,18 @@ async def poll_device_details(  # noqa: C901
             # Fetch other charger datails for supported models
             else:
                 pass
+        elif dev_type in ({SolixDeviceType.PPS.value} - exclude):
+            # PPS TOU plan (pps_use_time): only owned (admin) devices can query
+            # their plan; shared devices return an error, so guard with is_admin
+            if device.get("is_admin"):
+                try:
+                    await api.get_device_attributes(
+                        deviceSn=sn, attributes=["pps_use_time"], fromFile=fromFile
+                    )
+                except AnkerSolixError as err:
+                    api._logger.warning(
+                        f"Failed to fetch PPS TOU plan for {sn}: {err}"
+                    )
 
         # Merge additional powerpanel data
         if api.powerpanelApi:

--- a/src/anker_solix_api/schedule.py
+++ b/src/anker_solix_api/schedule.py
@@ -3140,10 +3140,15 @@ async def set_sb2_use_time(  # noqa: C901
 async def set_pps_use_time(
     self: AnkerSolixApi,
     deviceSn: str,
-    ranges: list[dict] | None = None,
-    prices: list[dict] | None = None,
-    unit: str | None = None,
-    reserve_power: int | None = None,
+    ranges: list[dict] | None = None,  # full replacement of the slot plan
+    prices: list[dict] | None = None,  # full replacement of the tariff prices
+    start_hour: int | datetime | time | None = None,  # 0-24
+    end_hour: int | datetime | time | None = None,  # 0-24
+    tariff_type: int | str | None = None,  # 1=Peak, 2=Mid, 3=Off
+    tariff_price: float | str | None = None,
+    delete: bool | None = False,
+    reserve_power: int | None = None,  # "TOU Power" backup reserve %
+    unit: str | None = None,  # currency symbol
     toFile: bool = False,
 ) -> bool | dict:
     r"""Set or change the PPS time-of-use (TOU) charging schedule for a given device.
@@ -3152,6 +3157,14 @@ async def set_pps_use_time(
     plan in the cloud "pps_use_time" device attribute (a JSON string). Writing
     this attribute via the Api is sufficient to update the plan: the cloud pushes
     the new schedule down to the device, so no direct MQTT command is required.
+
+    The helper supports two modes:
+    - Full replacement: pass ranges and/or prices to replace the whole slot plan
+      and/or the whole price list (all other parameters are ignored for the plan).
+    - Flexible partial change (mirroring set_sb2_use_time() but without the
+      seasonal month handling, since a PPS plan is hourly and always covers the
+      day): apply a change to a single slot. All parameters are optional; any
+      parameter left as None is preserved from the current plan.
 
     The "pps_use_time" attribute format (as returned by get_device_attributes):
     "{"ranges": [{"start_time": "00:00", "end_time": "09:00", "type": 1},
@@ -3164,20 +3177,99 @@ async def set_pps_use_time(
     1=Peak, 2=Mid, 3=Off.
 
     Applied Parameter logic:
-    - If no parameter is provided, read and return the current pps_use_time plan
-    - ranges: full replacement of the TOU slot plan, a list of
-        {"start_time": "HH:MM", "end_time": "HH:MM", "type": 1|2|3}
-        covering the day 00:00-24:00 with 1-6 contiguous slots
-    - prices: full replacement of the tariff prices, a list of
-        {"price": "<float>", "type": 1|2|3}
-    - unit: currency symbol (e.g. "$")
-    - reserve_power: backup reserve percentage (the app's "TOU Power" setting;
-        "power in use" = 100 - reserve_power). The app steps by 1% and enforces a
-        lower bound (observed floor: min_soc + 5, e.g. 6% when min_soc = 1)
-    - Any parameter left as None is preserved from the current plan
+    - Full replacement (takes precedence when provided):
+        - ranges: replace the TOU slot plan, a list of
+          {"start_time": "HH:MM", "end_time": "HH:MM", "type": 1|2|3}
+          covering the day 00:00-24:00 with 1-6 contiguous slots
+        - prices: replace the tariff prices, a list of
+          {"price": "<float>", "type": 1|2|3}
+    - Flexible partial change (applied to one target slot when no full
+      replacement is given):
+        - Target slot selection:
+            - If start_hour or end_hour is provided, the slot whose window
+              contains that time is modified (the "given slot").
+            - Otherwise the *active* slot (the slot containing the current
+              device-local time) is modified.
+        - tariff_type: set the target slot's tariff (1=Peak, 2=Mid, 3=Off);
+          the SolixTariffTypes name ("peak"/"mid_peak"/"off_peak") is also
+          accepted.
+        - tariff_price: set the price of the target slot's tariff in "prices".
+        - start_hour: move the target slot's start boundary and adjust the
+          previous slot's end to match (the plan stays contiguous).
+        - end_hour: move the target slot's end boundary and adjust the next
+          slot's start to match (the plan stays contiguous).
+        - delete: remove the target slot and fill the gap with the adjacent slot.
+    - Plan-level options (applied in either mode):
+        - reserve_power: backup reserve percentage (the app's "TOU Power"
+          setting; "power in use" = 100 - reserve_power). The app steps by 1%
+          and enforces a device-specific floor (min_soc + 5) and ceiling
+          (max_soc).
+        - unit: currency symbol (e.g. "$").
+    - If no parameter is provided, the current plan is returned without writing.
     - toFile: write to file for testing instead of making the Api call
     """
-    # Read the current plan (from file when toFile) so unset parameters are preserved
+
+    def _to_hhmm(value) -> str | None:
+        """Convert an int hour / datetime / time / 'HH:MM' to 'HH:MM', or None."""
+        if isinstance(value, datetime):
+            value = value.time()
+        if isinstance(value, time):
+            return f"{value.hour:02d}:{value.minute:02d}"
+        if str(value).isdigit() or isinstance(value, int | float):
+            return f"{max(0, min(24, int(value))):02d}:00"
+        if isinstance(value, str):
+            parts = value.split(":")
+            if len(parts) == 2 and all(part.isdigit() for part in parts):
+                hour, minute = int(parts[0]), int(parts[1])
+                if 0 <= hour <= 24 and 0 <= minute <= 59:
+                    return f"{hour:02d}:{minute:02d}"
+        return None
+
+    def _hhmm_to_min(value: str) -> int:
+        hour, minute = value.split(":")
+        return int(hour) * 60 + int(minute)
+
+    def _min_to_hhmm(value: int) -> str:
+        value = max(0, min(1440, value))
+        return f"{value // 60:02d}:{value % 60:02d}"
+
+    def _slot_at(ranges: list[dict], hhmm: str) -> int:
+        """Index of the slot whose [start_time, end_time) contains hhmm, else -1."""
+        for index, slot in enumerate(ranges):
+            if slot["start_time"] <= hhmm < slot["end_time"]:
+                return index
+        return -1
+
+    # normalize the parameters
+    start_hour = _to_hhmm(start_hour)
+    end_hour = _to_hhmm(end_hour)
+    tariff_type = (
+        # accept the SolixTariffTypes enum name (peak/mid_peak/off_peak) or the
+        # int value; PPS only supports Peak/Mid/Off (no Valley/Unknown)
+        int(getattr(SolixTariffTypes, str(tariff_type).upper()))
+        if hasattr(SolixTariffTypes, str(tariff_type).upper())
+        and getattr(SolixTariffTypes, str(tariff_type).upper()).value in (1, 2, 3)
+        else int(tariff_type)
+        if (str(tariff_type).isdigit() or isinstance(tariff_type, int | float))
+        and int(tariff_type) in (1, 2, 3)
+        else None
+    )
+    tariff_price = (
+        # preserve the price's native precision (PPS prices can be e.g. 0.001),
+        # stripping trailing zeros so 0.2 stays "0.2" and 0.001 stays "0.001"
+        f"{float(tariff_price):.6f}".rstrip("0").rstrip(".")
+        if str(tariff_price).replace(".", "", 1).isdigit()
+        else None
+    )
+    delete = delete if isinstance(delete, bool) else False
+    reserve_power = (
+        max(1, min(100, int(reserve_power)))
+        if (str(reserve_power).isdigit() or isinstance(reserve_power, int | float))
+        else None
+    )
+    unit = str(unit)[0:3] if unit else None
+
+    # read the current plan (from file when toFile) so unset parameters are preserved
     data = await self.get_device_attributes(
         deviceSn=deviceSn, attributes=["pps_use_time"], fromFile=toFile
     )
@@ -3187,16 +3279,108 @@ async def set_pps_use_time(
             pps = json.loads(pps)
     if not isinstance(pps, dict):
         pps = {}
-    # Apply the provided changes, preserving everything else
+    # no option provided -> return the current plan without writing
+    if not (
+        ranges
+        or prices
+        or start_hour
+        or end_hour
+        or tariff_type
+        or tariff_price
+        or delete
+        or reserve_power is not None
+        or unit
+    ):
+        self._logger.info(
+            "Api %s no PPS use time options provided, returning current plan",
+            self.apisession.nickname,
+        )
+        return pps
+
+    # full replacement takes precedence: replace the whole slot plan / price list
     if ranges is not None:
         pps["ranges"] = ranges
     if prices is not None:
         pps["prices"] = prices
-    if unit is not None:
+
+    # flexible partial change: apply to one target slot when the slot plan is not
+    # being fully replaced (ranges left as None)
+    if (
+        start_hour or end_hour or tariff_type or tariff_price or delete
+    ) and ranges is None:
+        cur_ranges: list[dict] = pps.get("ranges") or []
+        cur_prices: list[dict] = pps.get("prices") or []
+        if not cur_ranges:
+            # no existing plan; start from a single default off-peak slot
+            cur_ranges = [{"start_time": "00:00", "end_time": "24:00", "type": 3}]
+        # select the target slot: the slot at the given time, else the active slot
+        if start_hour or end_hour:
+            index = _slot_at(cur_ranges, start_hour or end_hour)
+        else:
+            index = _slot_at(cur_ranges, datetime.now().astimezone().strftime("%H:%M"))
+        if index < 0:
+            index = 0
+        if delete:
+            if len(cur_ranges) == 1:
+                # a single slot cannot be deleted; reset to the default plan
+                cur_ranges = [{"start_time": "00:00", "end_time": "24:00", "type": 3}]
+            elif index > 0:
+                # the previous slot absorbs the deleted slot
+                cur_ranges[index - 1]["end_time"] = cur_ranges[index]["end_time"]
+                del cur_ranges[index]
+            else:
+                # the next slot absorbs the deleted (first) slot
+                cur_ranges[1]["start_time"] = cur_ranges[0]["start_time"]
+                del cur_ranges[0]
+        else:
+            if tariff_type:
+                cur_ranges[index]["type"] = tariff_type
+            if tariff_price:
+                slot_type = cur_ranges[index]["type"]
+                for price in cur_prices:
+                    if price.get("type") == slot_type:
+                        price["price"] = tariff_price
+                        break
+                else:
+                    cur_prices.append({"price": tariff_price, "type": slot_type})
+            if start_hour:
+                if index > 0:
+                    lower = _hhmm_to_min(cur_ranges[index - 1]["start_time"])
+                    upper = _hhmm_to_min(cur_ranges[index]["end_time"])
+                    new_start = _min_to_hhmm(
+                        max(lower, min(upper - 1, _hhmm_to_min(start_hour)))
+                    )
+                    cur_ranges[index]["start_time"] = new_start
+                    cur_ranges[index - 1]["end_time"] = new_start
+                else:
+                    self._logger.warning(
+                        "Api %s cannot move the start of the first slot (stays 00:00)",
+                        self.apisession.nickname,
+                    )
+            if end_hour:
+                if index < len(cur_ranges) - 1:
+                    lower = _hhmm_to_min(cur_ranges[index]["start_time"])
+                    upper = _hhmm_to_min(cur_ranges[index + 1]["end_time"])
+                    new_end = _min_to_hhmm(
+                        max(lower + 1, min(upper, _hhmm_to_min(end_hour)))
+                    )
+                    cur_ranges[index]["end_time"] = new_end
+                    cur_ranges[index + 1]["start_time"] = new_end
+                else:
+                    self._logger.warning(
+                        "Api %s cannot move the end of the last slot (stays 24:00)",
+                        self.apisession.nickname,
+                    )
+        pps["ranges"] = cur_ranges
+        pps["prices"] = cur_prices
+
+    # apply the plan-level options
+    if unit:
         pps["unit"] = unit
     if reserve_power is not None:
         pps["reserve_power"] = reserve_power
-    # Commit to the cloud store; the cloud pushes the plan to the device
+
+    # commit to the cloud store; the cloud pushes the plan to the device
     return await self.set_device_attributes(
         deviceSn=deviceSn,
         attributes={"pps_use_time": json.dumps(pps, separators=(",", ":"))},

--- a/src/anker_solix_api/schedule.py
+++ b/src/anker_solix_api/schedule.py
@@ -3137,6 +3137,90 @@ async def set_sb2_use_time(  # noqa: C901
     return resp
 
 
+PPS_MAX_SLOTS = 6  # maximum TOU slots a PPS plan may define
+
+
+def _is_pps_hhmm(value) -> bool:
+    """True if value is a valid 'HH:MM' string in the 00:00-24:00 range."""
+    if not isinstance(value, str):
+        return False
+    parts = value.split(":")
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        return False
+    hour, minute = int(parts[0]), int(parts[1])
+    return 0 <= hour <= 24 and 0 <= minute <= 59
+
+
+def _validate_pps_plan(pps: dict) -> list[str]:
+    """Validate a PPS use time plan; return a list of problems (empty = valid).
+
+    Enforces the device plan limits required by issue #326: 1-6 contiguous slots
+    tiling 00:00-24:00 (a TOU plan has no gaps), valid tariff types, and a
+    well-formed price list.
+    """
+    problems: list[str] = []
+    ranges = pps.get("ranges")
+    if not isinstance(ranges, list) or not ranges:
+        problems.append("ranges must be a non-empty list")
+    else:
+        if len(ranges) > PPS_MAX_SLOTS:
+            problems.append(f"too many slots ({len(ranges)} > {PPS_MAX_SLOTS})")
+        for i, slot in enumerate(ranges):
+            if not isinstance(slot, dict):
+                problems.append(f"slot {i} is not an object")
+                continue
+            start, end = slot.get("start_time"), slot.get("end_time")
+            if not _is_pps_hhmm(start):
+                problems.append(f"slot {i} start_time {start!r} is not a valid HH:MM")
+            if not _is_pps_hhmm(end):
+                problems.append(f"slot {i} end_time {end!r} is not a valid HH:MM")
+            if (
+                _is_pps_hhmm(start)
+                and _is_pps_hhmm(end)
+                and start >= end
+            ):
+                problems.append(
+                    f"slot {i} start_time {start} is not before end_time {end}"
+                )
+            if slot.get("type") not in (1, 2, 3):
+                problems.append(f"slot {i} type {slot.get('type')!r} must be 1/2/3")
+        if not problems:
+            if ranges[0].get("start_time") != "00:00":
+                problems.append(
+                    "first slot must start at 00:00, "
+                    f"got {ranges[0].get('start_time')!r}"
+                )
+            if ranges[-1].get("end_time") != "24:00":
+                problems.append(
+                    "last slot must end at 24:00, "
+                    f"got {ranges[-1].get('end_time')!r}"
+                )
+            for i in range(len(ranges) - 1):
+                if ranges[i].get("end_time") != ranges[i + 1].get("start_time"):
+                    problems.append(
+                        f"gap/overlap between slot {i} "
+                        f"({ranges[i].get('end_time')}) and slot {i + 1} "
+                        f"({ranges[i + 1].get('start_time')})"
+                    )
+    prices = pps.get("prices")
+    if prices is not None:
+        if not isinstance(prices, list):
+            problems.append("prices must be a list")
+        else:
+            for i, price in enumerate(prices):
+                if not isinstance(price, dict):
+                    problems.append(f"price {i} is not an object")
+                    continue
+                if price.get("type") not in (1, 2, 3):
+                    problems.append(f"price {i} type {price.get('type')!r} must be 1/2/3")
+                try:
+                    if float(price.get("price")) < 0:
+                        problems.append(f"price {i} {price.get('price')!r} is negative")
+                except (TypeError, ValueError):
+                    problems.append(f"price {i} {price.get('price')!r} is not a number")
+    return problems
+
+
 async def set_pps_use_time(
     self: AnkerSolixApi,
     deviceSn: str,
@@ -3189,7 +3273,10 @@ async def set_pps_use_time(
             - If start_hour or end_hour is provided, the slot whose window
               contains that time is modified (the "given slot").
             - Otherwise the *active* slot (the slot containing the current
-              device-local time) is modified.
+              time of the library instance) is modified. No device-local
+              timestamp is exposed by the cloud, so if the device's local
+              time differs from the instance time, pass start_hour or
+              end_hour to target a specific slot explicitly.
         - tariff_type: set the target slot's tariff (1=Peak, 2=Mid, 3=Off);
           the SolixTariffTypes name ("peak"/"mid_peak"/"off_peak") is also
           accepted.
@@ -3206,6 +3293,10 @@ async def set_pps_use_time(
           (max_soc).
         - unit: currency symbol (e.g. "$").
     - If no parameter is provided, the current plan is returned without writing.
+    - The final plan is validated before writing (issue #326): 1-6 contiguous
+      slots tiling 00:00-24:00, valid tariff types and prices. If the result
+      is invalid, a warning is logged and the unmodified current plan is
+      returned without writing.
     - toFile: write to file for testing instead of making the Api call
     """
 
@@ -3281,10 +3372,15 @@ async def set_pps_use_time(
             pps = json.loads(pps)
     if not isinstance(pps, dict):
         pps = {}
+    # snapshot the current plan so an invalid result can be rejected without
+    # losing the unmodified plan
+    original_pps = copy.deepcopy(pps)
     # no option provided -> return the current plan without writing
+    # (ranges/prices count as "provided" when not None, so an explicitly empty
+    # list is validated and rejected rather than silently treated as a no-op)
     if not (
-        ranges
-        or prices
+        ranges is not None
+        or prices is not None
         or start_hour
         or end_hour
         or tariff_type
@@ -3381,6 +3477,17 @@ async def set_pps_use_time(
         pps["unit"] = unit
     if reserve_power is not None:
         pps["reserve_power"] = reserve_power
+
+    # validate the final plan before committing (issue #326: enforce the device
+    # plan limits - 1-6 contiguous slots tiling 00:00-24:00, valid types/prices);
+    # on failure warn and return the unmodified plan without writing
+    if problems := _validate_pps_plan(pps):
+        self._logger.warning(
+            "Api %s invalid PPS use time plan (%s); not writing",
+            self.apisession.nickname,
+            "; ".join(problems),
+        )
+        return original_pps
 
     # commit to the cloud store; the cloud pushes the plan to the device
     return await self.set_device_attributes(

--- a/src/anker_solix_api/schedule.py
+++ b/src/anker_solix_api/schedule.py
@@ -3231,6 +3231,7 @@ async def set_pps_use_time(
     tariff_type: int | str | None = None,  # 1=Peak, 2=Mid, 3=Off
     tariff_price: float | str | None = None,
     delete: bool | None = False,
+    slot: int | None = None,  # 1-based slot index for explicit targeting
     reserve_power: int | None = None,  # "TOU Power" backup reserve %
     unit: str | None = None,  # currency symbol
     toFile: bool = False,
@@ -3269,13 +3270,16 @@ async def set_pps_use_time(
           {"price": "<float>", "type": 1|2|3}
     - Flexible partial change (applied to one target slot when no full
       replacement is given):
-        - Target slot selection:
+        - Target slot selection (highest precedence first):
+            - slot: a 1-based index into the slot plan explicitly targets that
+              slot (e.g. slot=2 targets the second slot). start_hour/end_hour
+              then only set the target slot's boundaries.
             - If start_hour or end_hour is provided, the slot whose window
               contains that time is modified (the "given slot").
             - Otherwise the *active* slot (the slot containing the current
               time of the library instance) is modified. No device-local
               timestamp is exposed by the cloud, so if the device's local
-              time differs from the instance time, pass start_hour or
+              time differs from the instance time, pass slot, start_hour or
               end_hour to target a specific slot explicitly.
         - tariff_type: set the target slot's tariff (1=Peak, 2=Mid, 3=Off);
           the SolixTariffTypes name ("peak"/"mid_peak"/"off_peak") is also
@@ -3355,6 +3359,11 @@ async def set_pps_use_time(
         else None
     )
     delete = delete if isinstance(delete, bool) else False
+    slot = (
+        int(slot)
+        if (str(slot).isdigit() or isinstance(slot, int)) and int(slot) > 0
+        else None
+    )
     reserve_power = (
         max(1, min(100, int(reserve_power)))
         if (str(reserve_power).isdigit() or isinstance(reserve_power, int | float))
@@ -3386,6 +3395,7 @@ async def set_pps_use_time(
         or tariff_type
         or tariff_price
         or delete
+        or slot is not None
         or reserve_power is not None
         or unit
     ):
@@ -3404,19 +3414,34 @@ async def set_pps_use_time(
     # flexible partial change: apply to one target slot when the slot plan is not
     # being fully replaced (ranges left as None)
     if (
-        start_hour or end_hour or tariff_type or tariff_price or delete
+        start_hour
+        or end_hour
+        or tariff_type
+        or tariff_price
+        or delete
+        or slot is not None
     ) and ranges is None:
         cur_ranges: list[dict] = pps.get("ranges") or []
         cur_prices: list[dict] = pps.get("prices") or []
         if not cur_ranges:
             # no existing plan; start from a single default off-peak slot
             cur_ranges = [{"start_time": "00:00", "end_time": "24:00", "type": 3}]
-        # select the target slot: the slot at the given time, else the active slot
-        if start_hour or end_hour:
+        # select the target slot: explicit slot index, else the slot at the given
+        # time, else the active slot
+        if slot is not None:
+            index = slot - 1  # 1-based to 0-based
+        elif start_hour or end_hour:
             index = _slot_at(cur_ranges, start_hour or end_hour)
         else:
             index = _slot_at(cur_ranges, datetime.now().astimezone().strftime("%H:%M"))
-        if index < 0:
+        if index < 0 or index >= len(cur_ranges):
+            if slot is not None:
+                self._logger.warning(
+                    "Api %s PPS slot %s out of range (1-%d); targeting slot 1",
+                    self.apisession.nickname,
+                    slot,
+                    len(cur_ranges),
+                )
             index = 0
         if delete:
             if len(cur_ranges) == 1:

--- a/src/anker_solix_api/schedule.py
+++ b/src/anker_solix_api/schedule.py
@@ -3135,3 +3135,71 @@ async def set_sb2_use_time(  # noqa: C901
             siteId=siteId, price_type=new_price_type, toFile=toFile
         )
     return resp
+
+
+async def set_pps_use_time(
+    self: AnkerSolixApi,
+    deviceSn: str,
+    ranges: list[dict] | None = None,
+    prices: list[dict] | None = None,
+    unit: str | None = None,
+    reserve_power: int | None = None,
+    toFile: bool = False,
+) -> bool | dict:
+    r"""Set or change the PPS time-of-use (TOU) charging schedule for a given device.
+
+    PPS devices (e.g. SOLIX C1000 Gen 2, model A1763) store their TOU charging
+    plan in the cloud "pps_use_time" device attribute (a JSON string). Writing
+    this attribute via the Api is sufficient to update the plan: the cloud pushes
+    the new schedule down to the device, so no direct MQTT command is required.
+
+    The "pps_use_time" attribute format (as returned by get_device_attributes):
+    "{"ranges": [{"start_time": "00:00", "end_time": "09:00", "type": 1},
+                 {"start_time": "09:00", "end_time": "19:00", "type": 3},
+                 {"start_time": "19:00", "end_time": "24:00", "type": 1}],
+     "prices": [{"price": "0.2", "type": 1}, {"price": "0.001", "type": 3}],
+     "unit": "$", "reserve_power": 6}"
+
+    Tariff types (the cloud calls this "type", the Anker app "tariff"):
+    1=Peak, 2=Mid, 3=Off.
+
+    Applied Parameter logic:
+    - If no parameter is provided, read and return the current pps_use_time plan
+    - ranges: full replacement of the TOU slot plan, a list of
+        {"start_time": "HH:MM", "end_time": "HH:MM", "type": 1|2|3}
+        covering the day 00:00-24:00 with 1-6 contiguous slots
+    - prices: full replacement of the tariff prices, a list of
+        {"price": "<float>", "type": 1|2|3}
+    - unit: currency symbol (e.g. "$")
+    - reserve_power: backup reserve percentage (the app's "TOU Power" setting;
+        "power in use" = 100 - reserve_power). The app steps by 1% and enforces a
+        lower bound (observed floor: min_soc + 5, e.g. 6% when min_soc = 1)
+    - Any parameter left as None is preserved from the current plan
+    - toFile: write to file for testing instead of making the Api call
+    """
+    # Read the current plan (from file when toFile) so unset parameters are preserved
+    data = await self.get_device_attributes(
+        deviceSn=deviceSn, attributes=["pps_use_time"], fromFile=toFile
+    )
+    pps = (data.get("attributes") or {}).get("pps_use_time")
+    if isinstance(pps, str):
+        with contextlib.suppress(ValueError, TypeError):
+            pps = json.loads(pps)
+    if not isinstance(pps, dict):
+        pps = {}
+    # Apply the provided changes, preserving everything else
+    if ranges is not None:
+        pps["ranges"] = ranges
+    if prices is not None:
+        pps["prices"] = prices
+    if unit is not None:
+        pps["unit"] = unit
+    if reserve_power is not None:
+        pps["reserve_power"] = reserve_power
+    # Commit to the cloud store; the cloud pushes the plan to the device
+    return await self.set_device_attributes(
+        deviceSn=deviceSn,
+        attributes={"pps_use_time": json.dumps(pps, separators=(",", ":"))},
+        query_attributes=["pps_use_time"],
+        toFile=toFile,
+    )

--- a/src/anker_solix_api/schedule.py
+++ b/src/anker_solix_api/schedule.py
@@ -3151,15 +3151,17 @@ def _is_pps_hhmm(value) -> bool:
     return 0 <= hour <= 24 and 0 <= minute <= 59
 
 
-def _validate_pps_plan(pps: dict) -> list[str]:
-    """Validate a PPS use time plan; return a list of problems (empty = valid).
+def validate_pps_schedule(ranges, prices) -> list[str]:
+    """Authoritative PPS schedule validation; return a list of problems (empty = valid).
 
     Enforces the device plan limits required by issue #326: 1-6 contiguous slots
-    tiling 00:00-24:00 (a TOU plan has no gaps), valid tariff types, and a
-    well-formed price list.
+    tiling 00:00-24:00 (no gaps, no overlaps, monotonically increasing
+    boundaries, first slot starts 00:00, last ends 24:00), valid tariff types
+    (1/2/3), and a well-formed price list (valid types, non-negative numeric
+    prices) when a price list is provided. This is the single validation path
+    every PPS write goes through immediately before the cloud request.
     """
     problems: list[str] = []
-    ranges = pps.get("ranges")
     if not isinstance(ranges, list) or not ranges:
         problems.append("ranges must be a non-empty list")
     else:
@@ -3202,7 +3204,6 @@ def _validate_pps_plan(pps: dict) -> list[str]:
                         f"({ranges[i].get('end_time')}) and slot {i + 1} "
                         f"({ranges[i + 1].get('start_time')})"
                     )
-    prices = pps.get("prices")
     if prices is not None:
         if not isinstance(prices, list):
             problems.append("prices must be a list")
@@ -3337,6 +3338,38 @@ async def set_pps_use_time(
                 return index
         return -1
 
+    def _resolve_slot(
+        ranges: list[dict],
+        slot: int | None = None,
+        start_hour: str | None = None,
+        end_hour: str | None = None,
+        active_index: int | None = None,
+    ) -> int:
+        """Resolve the 0-based index of the target slot for a PPS partial change.
+
+        Precedence: explicit slot > explicit time > active slot. An explicitly
+        supplied slot is authoritative and is never silently redirected to a
+        different slot: an out-of-range slot, a time that maps to no slot, or the
+        absence of an active slot all raise ValueError so the caller writes
+        nothing rather than mutating an unintended slot.
+        """
+        if slot is not None:
+            if not isinstance(slot, int) or isinstance(slot, bool):
+                raise ValueError("slot must be an integer")
+            if slot < 1 or slot > len(ranges):
+                raise ValueError(
+                    f"slot must be between 1 and {len(ranges)}, got {slot}"
+                )
+            return slot - 1
+        if start_hour is not None or end_hour is not None:
+            index = _slot_at(ranges, start_hour or end_hour)
+            if index < 0:
+                raise ValueError(f"no PPS slot contains {start_hour or end_hour}")
+            return index
+        if active_index is not None and 0 <= active_index < len(ranges):
+            return active_index
+        raise ValueError("no active PPS slot for the current time")
+
     # normalize the parameters
     start_hour = _to_hhmm(start_hour)
     end_hour = _to_hhmm(end_hour)
@@ -3427,22 +3460,22 @@ async def set_pps_use_time(
             # no existing plan; start from a single default off-peak slot
             cur_ranges = [{"start_time": "00:00", "end_time": "24:00", "type": 3}]
         # select the target slot: explicit slot index, else the slot at the given
-        # time, else the active slot
-        if slot is not None:
-            index = slot - 1  # 1-based to 0-based
-        elif start_hour or end_hour:
-            index = _slot_at(cur_ranges, start_hour or end_hour)
-        else:
-            index = _slot_at(cur_ranges, datetime.now().astimezone().strftime("%H:%M"))
-        if index < 0 or index >= len(cur_ranges):
-            if slot is not None:
-                self._logger.warning(
-                    "Api %s PPS slot %s out of range (1-%d); targeting slot 1",
-                    self.apisession.nickname,
-                    slot,
-                    len(cur_ranges),
-                )
-            index = 0
+        # time, else the active slot. An unresolvable target raises (no write)
+        # rather than silently redirecting to slot 1.
+        active_index = (
+            None
+            if (slot is not None or start_hour or end_hour)
+            else _slot_at(
+                cur_ranges, datetime.now().astimezone().strftime("%H:%M")
+            )
+        )
+        index = _resolve_slot(
+            cur_ranges,
+            slot=slot,
+            start_hour=start_hour,
+            end_hour=end_hour,
+            active_index=active_index,
+        )
         if delete:
             if len(cur_ranges) == 1:
                 # a single slot cannot be deleted; reset to the default plan
@@ -3459,6 +3492,11 @@ async def set_pps_use_time(
             if tariff_type:
                 cur_ranges[index]["type"] = tariff_type
             if tariff_price:
+                # Upsert only the target segment's tariff price into the existing
+                # price list: update the entry matching the target slot's tariff
+                # type, or append it if absent. Every other range and price entry
+                # is preserved verbatim (no rebuild/normalize/merge of unrelated
+                # schedule boundaries).
                 slot_type = cur_ranges[index]["type"]
                 for price in cur_prices:
                     if price.get("type") == slot_type:
@@ -3505,8 +3543,11 @@ async def set_pps_use_time(
 
     # validate the final plan before committing (issue #326: enforce the device
     # plan limits - 1-6 contiguous slots tiling 00:00-24:00, valid types/prices);
-    # on failure warn and return the unmodified plan without writing
-    if problems := _validate_pps_plan(pps):
+    # on failure warn and return the unmodified plan without writing. The local
+    # cache is only refreshed by set_device_attributes after a *successful*
+    # cloud write, so a rejected/failed write never leaves optimistic local
+    # state behind.
+    if problems := validate_pps_schedule(pps.get("ranges"), pps.get("prices")):
         self._logger.warning(
             "Api %s invalid PPS use time plan (%s); not writing",
             self.apisession.nickname,
@@ -3514,7 +3555,9 @@ async def set_pps_use_time(
         )
         return original_pps
 
-    # commit to the cloud store; the cloud pushes the plan to the device
+    # commit to the cloud store; the cloud pushes the plan to the device. The
+    # cached plan is updated from the confirmed result only after this write
+    # succeeds, so a failed write cannot corrupt the local state.
     return await self.set_device_attributes(
         deviceSn=deviceSn,
         attributes={"pps_use_time": json.dumps(pps, separators=(",", ":"))},

--- a/src/anker_solix_api/schedule.py
+++ b/src/anker_solix_api/schedule.py
@@ -3219,7 +3219,9 @@ async def set_pps_use_time(
             return f"{max(0, min(24, int(value))):02d}:00"
         if isinstance(value, str):
             parts = value.split(":")
-            if len(parts) == 2 and all(part.isdigit() for part in parts):
+            if 2 <= len(parts) <= 3 and all(part.isdigit() for part in parts):
+                # accept "HH:MM" and the "HH:MM:SS" format used by the Home
+                # Assistant time selector (seconds are ignored)
                 hour, minute = int(parts[0]), int(parts[1])
                 if 0 <= hour <= 24 and 0 <= minute <= 59:
                     return f"{hour:02d}:{minute:02d}"

--- a/tests/test_pps_use_time.py
+++ b/tests/test_pps_use_time.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Live round-trip test for the flexible set_pps_use_time() helper (A1763 PPS TOU).
+
+Demonstrates the helper flexibility requested in issue #326:
+  - individual parameter updates that modify the active or a given slot
+    (tariff by int or by SolixTariffTypes name, price, start/end boundary moves
+    with neighbor auto-adjust, slot delete with gap fill)
+  - whole-slot plan replacement via ranges
+  - plan-level reserve_power
+  - plan validation (an invalid plan is rejected without writing)
+
+Each step mutates, reads back, verifies, then restores the exact baseline, so
+the device always ends at its original plan (safe to run against a live unit).
+Set FOLDER to run against exported files instead of a live account.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path  # noqa: F401
+import traceback
+
+from aiohttp import ClientSession
+from anker_solix_api.api import AnkerSolixApi
+from context import common
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+CONSOLE: logging.Logger = common.CONSOLE
+# Specify FOLDER with a system export including pps_use_time for testing from files
+# FOLDER = Path(__file__).parent / "exports" / "Mqtt_C1000_Gen2"
+FOLDER = None
+
+
+def _plan(data: dict) -> dict:
+    """Extract the pps_use_time plan dict from a get_device_attributes response."""
+    pps = (data.get("attributes") or {}).get("pps_use_time")
+    if isinstance(pps, str):
+        pps = json.loads(pps)
+    return pps if isinstance(pps, dict) else {}
+
+
+def _shape(plan: dict) -> list:
+    return [(r.get("start_time"), r.get("end_time"), r.get("type")) for r in plan.get("ranges", [])]
+
+
+def _contiguous(plan: dict) -> bool:
+    ranges = plan.get("ranges") or []
+    if not ranges:
+        return False
+    if ranges[0].get("start_time") != "00:00" or ranges[-1].get("end_time") != "24:00":
+        return False
+    for i in range(len(ranges) - 1):
+        if ranges[i].get("end_time") != ranges[i + 1].get("start_time"):
+            return False
+    for r in ranges:
+        if not (r.get("start_time") and r.get("end_time") and r["start_time"] < r["end_time"]):
+            return False
+    return True
+
+
+def _hhmm_to_min(value: str) -> int:
+    hour, minute = value.split(":")
+    return int(hour) * 60 + int(minute)
+
+
+def _min_to_hhmm(minutes: int) -> str:
+    minutes = max(0, min(1440, minutes))
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+class _Reporter:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def ok(self, label: str) -> None:
+        self.passed += 1
+        CONSOLE.info(f"    [PASS] {label}")
+
+    def fail(self, label: str, detail: str = "") -> None:
+        self.failed += 1
+        CONSOLE.info(f"    [FAIL] {label} {detail}")
+
+
+async def test_pps_use_time() -> None:  # noqa: C901
+    """Run the safe set_pps_use_time round-trip against an A1763 device."""
+    async with ClientSession() as websession:
+        myapi = AnkerSolixApi(
+            common.user(), common.password(), common.country(), websession, _LOGGER
+        )
+        use_file = bool(FOLDER)
+        if use_file:
+            myapi.testDir(FOLDER)
+
+        await myapi.update_sites(fromFile=use_file)
+        await myapi.update_device_details(fromFile=use_file)
+
+        # find an A1763 (C1000 Gen 2) device
+        device_sn = None
+        for sn, device in myapi.devices.items():
+            if device.get("device_pn") in ["A1761", "A1763", "A1765"]:
+                device_sn = sn
+                CONSOLE.info(f"Found C1000X device: {sn}")
+                break
+        if not device_sn:
+            CONSOLE.info("No C1000X device found")
+            return
+
+        rep = _Reporter()
+        toFile = use_file
+
+        # read the baseline plan
+        base_data = await myapi.get_device_attributes(
+            deviceSn=device_sn, attributes=["pps_use_time"], fromFile=toFile
+        )
+        baseline = _plan(base_data)
+        if not baseline.get("ranges"):
+            CONSOLE.info("Device has no pps_use_time plan; nothing to test")
+            return
+        CONSOLE.info(f"Baseline plan: {_shape(baseline)}")
+        baseline_json = json.dumps(baseline, separators=(",", ":"))
+
+        async def restore() -> bool:
+            """Write the exact baseline back and confirm it round-trips."""
+            await myapi.set_device_attributes(
+                deviceSn=device_sn,
+                attributes={"pps_use_time": baseline_json},
+                query_attributes=["pps_use_time"],
+                toFile=toFile,
+            )
+            check = _plan(
+                await myapi.get_device_attributes(
+                    deviceSn=device_sn, attributes=["pps_use_time"], fromFile=toFile
+                )
+            )
+            return check == baseline
+
+        async def step(label: str, kwargs: dict, verify) -> None:
+            """Apply a mutation, verify the result, then restore the baseline."""
+            try:
+                await myapi.set_pps_use_time(deviceSn=device_sn, toFile=toFile, **kwargs)
+                plan = _plan(
+                    await myapi.get_device_attributes(
+                        deviceSn=device_sn, attributes=["pps_use_time"], fromFile=toFile
+                    )
+                )
+                if verify(plan):
+                    rep.ok(label)
+                else:
+                    rep.fail(label, f"got {_shape(plan)}")
+            except Exception as err:  # noqa: BLE001
+                rep.fail(label, f"error: {err}")
+            finally:
+                if not await restore():
+                    rep.fail(f"{label}: baseline restore", "baseline not restored")
+
+        ranges = baseline.get("ranges") or []
+        n = len(ranges)
+
+        # --- individual parameter updates (active / given slot) ---
+        # 1. active-slot tariff (no time given) -> the slot containing now
+        await step(
+            "active-slot tariff (int)",
+            {"tariff_type": 2},
+            lambda p: _contiguous(p) and any(r.get("type") == 2 for r in p["ranges"]),
+        )
+        # 2. given-slot tariff by SolixTariffTypes name (slot at the first boundary)
+        if n >= 2:
+            await step(
+                "given-slot tariff (name 'off_peak')",
+                {"start_hour": ranges[0]["start_time"], "tariff_type": "off_peak"},
+                lambda p: _contiguous(p) and p["ranges"][0].get("type") == 3,
+            )
+        # 3. given-slot price
+        if n >= 2:
+            await step(
+                "given-slot price",
+                {"start_hour": ranges[0]["start_time"], "tariff_price": 0.123},
+                lambda p: _contiguous(p)
+                and any(str(pr.get("price")).startswith("0.123") for pr in p.get("prices", [])),
+            )
+        # 4. move an interior boundary (start of slot 1) to the midpoint of slot 1,
+        #    exercising the neighbor auto-adjust (slot 0 end follows)
+        if n >= 3:
+            s1_start = _hhmm_to_min(ranges[1]["start_time"])
+            s1_end = _hhmm_to_min(ranges[1]["end_time"])
+            new_start = _min_to_hhmm((s1_start + s1_end) // 2)
+            await step(
+                "move interior boundary (start_hour, neighbor auto-adjust)",
+                {"start_hour": new_start},
+                lambda p: _contiguous(p)
+                and len(p["ranges"]) == n
+                and p["ranges"][1].get("start_time") == new_start
+                and p["ranges"][0].get("end_time") == new_start,
+            )
+        # 5. slot delete with gap fill (only when there is more than one slot)
+        if n >= 2:
+            await step(
+                "slot delete (gap fill)",
+                {"start_hour": ranges[0]["start_time"], "delete": True},
+                lambda p: _contiguous(p) and len(p["ranges"]) == n - 1,
+            )
+        # 6. plan-level reserve_power (ranges untouched)
+        await step(
+            "reserve_power (plan-level)",
+            {"reserve_power": 10},
+            lambda p: p.get("reserve_power") == 10 and _shape(p) == _shape(baseline),
+        )
+
+        # --- whole-slot plan replacement via ranges ---
+        if n >= 2:
+            # 7. full replacement with a valid 2-slot plan (then restored)
+            two = [
+                {"start_time": "00:00", "end_time": "12:00", "type": 1},
+                {"start_time": "12:00", "end_time": "24:00", "type": 3},
+            ]
+            await step(
+                "full-replacement ranges (valid 2-slot)",
+                {"ranges": two},
+                lambda p: p.get("ranges") == two and _contiguous(p),
+            )
+
+        # --- validation: an invalid plan must be rejected without writing ---
+        await step(
+            "invalid plan rejected (gap, no write)",
+            {"ranges": [
+                {"start_time": "00:00", "end_time": "09:00", "type": 1},
+                {"start_time": "10:00", "end_time": "24:00", "type": 3},  # gap 09-10
+            ]},
+            lambda p: p == baseline,  # rejected -> plan unchanged
+        )
+
+        # --- final: confirm the device is back at the exact baseline ---
+        final = _plan(
+            await myapi.get_device_attributes(
+                deviceSn=device_sn, attributes=["pps_use_time"], fromFile=toFile
+            )
+        )
+        if final == baseline:
+            rep.ok("final state == baseline")
+        else:
+            rep.fail("final state == baseline", f"got {_shape(final)}")
+
+        CONSOLE.info(
+            f"\nRESULT: {rep.passed} passed, {rep.failed} failed"
+            + ("" if rep.failed == 0 else "  <-- CHECK FAILURES")
+        )
+        if rep.failed:
+            raise RuntimeError(f"{rep.failed} step(s) failed")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(test_pps_use_time(), debug=False)
+    except Exception as err:  # noqa: BLE001
+        CONSOLE.info(f"{type(err)}: {err}")
+        traceback.print_exc()

--- a/tests/test_pps_use_time_slot.py
+++ b/tests/test_pps_use_time_slot.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Mock test for the explicit `slot` targeting in set_pps_use_time() (A1763 PPS TOU).
+"""Mock tests for slot targeting and price mutation in set_pps_use_time() (A1763 PPS TOU).
 
-Verifies the 1-based `slot` parameter added for explicit per-slot targeting:
+Verifies the 1-based `slot` parameter and the safety invariants:
 - slot selects the target slot by index (start_hour/end_hour then only move the
   target slot's boundaries)
-- out-of-range slot warns and falls back to slot 1
+- an explicitly out-of-range slot raises ValueError and writes nothing (it never
+  silently falls back to slot 1)
 - no slot falls back to time-based / active-slot selection
+- a price change upserts only the target segment's tariff price and preserves
+  every other range and price entry
+- a failed cloud write does not update the cached (local) plan
 
 Runs without a live account: get_device_attributes / set_device_attributes are
-mocked, so this is a pure unit test of the slot-targeting logic.
+mocked, so this is a pure unit test of the slot-targeting / price-mutation logic.
 """
 
 import asyncio
+import copy
 import json
 import logging
 import sys
@@ -19,7 +24,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
 
-from anker_solix_api.schedule import set_pps_use_time  # noqa: E402
+from anker_solix_api.schedule import (  # noqa: E402
+    set_pps_use_time,
+    validate_pps_schedule,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,22 +45,38 @@ PLAN = {
 
 
 class FakeApi:
-    """Minimal AnkerSolixApi stand-in that mocks the two attribute calls."""
+    """Minimal AnkerSolixApi stand-in that mocks the two attribute calls.
 
-    def __init__(self):
+    Maintains a `cache` of the device's current pps_use_time plan to mirror the
+    real Api's behavior: the cache is only updated after a *successful* cloud
+    write, so a failed write leaves the cached (local) state unchanged.
+    """
+
+    def __init__(self, fail_write: bool = False):
         self._logger = _LOGGER
 
         class _Session:
             nickname = "mock"
 
         self.apisession = _Session()
+        self.fail_write = fail_write
         self.written: dict | None = None
+        self.write_called = False
+        # the device's current plan (the "cache" the real Api maintains)
+        self.cache = copy.deepcopy(PLAN)
 
     async def get_device_attributes(self, deviceSn, attributes, fromFile=False):
-        return {"attributes": {"pps_use_time": json.dumps(PLAN)}}
+        return {"attributes": {"pps_use_time": json.dumps(self.cache)}}
 
-    async def set_device_attributes(self, deviceSn, attributes, query_attributes=None, toFile=False):
+    async def set_device_attributes(
+        self, deviceSn, attributes, query_attributes=None, toFile=False
+    ):
+        self.write_called = True
+        if self.fail_write:
+            # cloud write failed: the cache is NOT updated
+            return False
         self.written = attributes["pps_use_time"]
+        self.cache = json.loads(attributes["pps_use_time"])
         return True
 
 
@@ -93,15 +117,6 @@ async def test_slot_targeting() -> None:
         ("19:00", "24:00", 1),
     ], f"slot=1 end=5 failed: {_shapes(api)}"
 
-    # out-of-range slot=99 warns and falls back to slot 1
-    api = FakeApi()
-    await set_pps_use_time(api, "SN", slot=99, tariff_type=2)
-    assert _shapes(api) == [
-        ("00:00", "09:00", 2),  # slot 1 now mid
-        ("09:00", "19:00", 3),
-        ("19:00", "24:00", 1),
-    ], f"slot=99 fallback failed: {_shapes(api)}"
-
     # no slot: time-based / active-slot selection still works (writes something)
     api = FakeApi()
     await set_pps_use_time(api, "SN", tariff_type=2)
@@ -110,6 +125,93 @@ async def test_slot_targeting() -> None:
     _LOGGER.info("All PPS use-time slot targeting tests passed")
 
 
+async def test_invalid_slot_does_not_modify_plan() -> None:
+    # an explicitly out-of-range slot must raise and write nothing (no silent
+    # fallback to slot 1)
+    api = FakeApi()
+    try:
+        await set_pps_use_time(api, "SN", slot=99, tariff_price="0.3")
+        raise AssertionError("slot=99 should raise ValueError")
+    except ValueError:
+        pass
+    assert not api.write_called, "invalid slot must not write"
+    assert api.cache == PLAN, "invalid slot must not modify the plan"
+    _LOGGER.info("Invalid-slot rejection test passed")
+
+
+async def test_price_write_preserves_other_ranges_and_prices() -> None:
+    # Changing a slot's tariff price upserts only that tariff type's price and
+    # preserves every other range and price entry (no rebuild/normalize).
+    api = FakeApi()
+    await set_pps_use_time(api, "SN", slot=2, tariff_price="0.3")
+    plan = json.loads(api.written)
+    # ranges are unchanged
+    assert plan["ranges"] == PLAN["ranges"], f"ranges changed: {plan['ranges']}"
+    # slot 2 is type 3 (off); its price was updated to 0.3
+    prices = {p["type"]: p["price"] for p in plan["prices"]}
+    assert prices[3] == "0.3", f"slot 2 (type 3) price not updated: {prices}"
+    # the other price entry (type 1) is preserved verbatim
+    assert prices[1] == "0.2", f"type 1 price not preserved: {prices}"
+    _LOGGER.info("Price-preservation test passed")
+
+
+async def test_failed_write_does_not_update_cache() -> None:
+    # A failed cloud write must not update the cached (local) plan.
+    api = FakeApi(fail_write=True)
+    original_cache = copy.deepcopy(api.cache)
+    result = await set_pps_use_time(api, "SN", slot=2, tariff_price="0.3")
+    # the write failed, so the result is a failure indicator (False)
+    assert result is False, f"failed write should return False, got {result!r}"
+    # the cached plan is unchanged (no optimistic local state)
+    assert api.cache == original_cache, "failed write must not update the cache"
+    _LOGGER.info("Failed-write cache test passed")
+
+
+def test_validator_edge_cases() -> None:
+    # a 6-slot schedule tiling 00:00-24:00 is valid
+    six = [
+        {"start_time": "00:00", "end_time": "04:00", "type": 1},
+        {"start_time": "04:00", "end_time": "08:00", "type": 3},
+        {"start_time": "08:00", "end_time": "12:00", "type": 1},
+        {"start_time": "12:00", "end_time": "16:00", "type": 2},
+        {"start_time": "16:00", "end_time": "20:00", "type": 3},
+        {"start_time": "20:00", "end_time": "24:00", "type": 1},
+    ]
+    assert validate_pps_schedule(six, None) == [], "6-slot schedule must be valid"
+
+    # 7 slots exceeds the device limit
+    seven = six + [{"start_time": "24:00", "end_time": "24:00", "type": 1}]
+    assert validate_pps_schedule(seven, None) != [], "7 slots must be rejected"
+
+    # a gap between slots is rejected
+    gapped = [
+        {"start_time": "00:00", "end_time": "06:00", "type": 1},
+        {"start_time": "07:00", "end_time": "24:00", "type": 3},
+    ]
+    assert validate_pps_schedule(gapped, None) != [], "gap must be rejected"
+
+    # a plan that does not start at 00:00 is rejected
+    no_midnight = [
+        {"start_time": "01:00", "end_time": "24:00", "type": 1},
+    ]
+    assert validate_pps_schedule(no_midnight, None) != [], "must start at 00:00"
+
+    # a well-formed 1-slot plan tiling the whole day is valid
+    one = [{"start_time": "00:00", "end_time": "24:00", "type": 3}]
+    assert validate_pps_schedule(one, None) == [], "1-slot schedule must be valid"
+
+    _LOGGER.info("Validator edge-case tests passed")
+
+
+async def main() -> None:
+    await test_slot_targeting()
+    await test_invalid_slot_does_not_modify_plan()
+    await test_price_write_preserves_other_ranges_and_prices()
+    await test_failed_write_does_not_update_cache()
+    test_validator_edge_cases()
+    _LOGGER.info("All PPS use-time tests passed")
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    asyncio.run(test_slot_targeting())
+    asyncio.run(main())

--- a/tests/test_pps_use_time_slot.py
+++ b/tests/test_pps_use_time_slot.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Mock test for the explicit `slot` targeting in set_pps_use_time() (A1763 PPS TOU).
+
+Verifies the 1-based `slot` parameter added for explicit per-slot targeting:
+- slot selects the target slot by index (start_hour/end_hour then only move the
+  target slot's boundaries)
+- out-of-range slot warns and falls back to slot 1
+- no slot falls back to time-based / active-slot selection
+
+Runs without a live account: get_device_attributes / set_device_attributes are
+mocked, so this is a pure unit test of the slot-targeting logic.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
+
+from anker_solix_api.schedule import set_pps_use_time  # noqa: E402
+
+_LOGGER = logging.getLogger(__name__)
+
+# Baseline plan: 3 slots (00-09 peak, 09-19 off, 19-24 peak)
+PLAN = {
+    "ranges": [
+        {"start_time": "00:00", "end_time": "09:00", "type": 1},
+        {"start_time": "09:00", "end_time": "19:00", "type": 3},
+        {"start_time": "19:00", "end_time": "24:00", "type": 1},
+    ],
+    "prices": [{"price": "0.2", "type": 1}, {"price": "0.001", "type": 3}],
+    "unit": "$",
+    "reserve_power": 6,
+}
+
+
+class FakeApi:
+    """Minimal AnkerSolixApi stand-in that mocks the two attribute calls."""
+
+    def __init__(self):
+        self._logger = _LOGGER
+
+        class _Session:
+            nickname = "mock"
+
+        self.apisession = _Session()
+        self.written: dict | None = None
+
+    async def get_device_attributes(self, deviceSn, attributes, fromFile=False):
+        return {"attributes": {"pps_use_time": json.dumps(PLAN)}}
+
+    async def set_device_attributes(self, deviceSn, attributes, query_attributes=None, toFile=False):
+        self.written = attributes["pps_use_time"]
+        return True
+
+
+def _shapes(api: FakeApi) -> list:
+    """The (start, end, type) shape of the written plan's slots."""
+    plan = json.loads(api.written) if api.written else None
+    if not plan:
+        return []
+    return [(r["start_time"], r["end_time"], r["type"]) for r in plan["ranges"]]
+
+
+def _prices(api: FakeApi) -> dict:
+    plan = json.loads(api.written) if api.written else None
+    return {p["type"]: p["price"] for p in (plan or {}).get("prices", [])}
+
+
+async def test_slot_targeting() -> None:
+    # slot=2 (1-based) targets the 2nd slot (09-19, off); set its tariff to peak
+    api = FakeApi()
+    await set_pps_use_time(api, "SN", slot=2, tariff_type=1)
+    assert _shapes(api) == [
+        ("00:00", "09:00", 1),
+        ("09:00", "19:00", 1),  # 2nd slot now peak
+        ("19:00", "24:00", 1),
+    ], f"slot=2 tariff=1 failed: {_shapes(api)}"
+
+    # slot=3 targets the 3rd slot (19-24, peak); set its price to 0.5
+    api = FakeApi()
+    await set_pps_use_time(api, "SN", slot=3, tariff_price="0.5")
+    assert _prices(api)[1] == "0.5", f"slot=3 price=0.5 failed: {_prices(api)}"
+
+    # slot=1 end_hour=5 moves the 1st slot's end to 05:00 (2nd slot start follows)
+    api = FakeApi()
+    await set_pps_use_time(api, "SN", slot=1, end_hour=5)
+    assert _shapes(api) == [
+        ("00:00", "05:00", 1),
+        ("05:00", "19:00", 3),
+        ("19:00", "24:00", 1),
+    ], f"slot=1 end=5 failed: {_shapes(api)}"
+
+    # out-of-range slot=99 warns and falls back to slot 1
+    api = FakeApi()
+    await set_pps_use_time(api, "SN", slot=99, tariff_type=2)
+    assert _shapes(api) == [
+        ("00:00", "09:00", 2),  # slot 1 now mid
+        ("09:00", "19:00", 3),
+        ("19:00", "24:00", 1),
+    ], f"slot=99 fallback failed: {_shapes(api)}"
+
+    # no slot: time-based / active-slot selection still works (writes something)
+    api = FakeApi()
+    await set_pps_use_time(api, "SN", tariff_type=2)
+    assert api.written is not None, "no-slot active-slot write failed"
+
+    _LOGGER.info("All PPS use-time slot targeting tests passed")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(test_slot_targeting())


### PR DESCRIPTION
This is the follow-up to the HA PR (thomluther/ha-anker-solix#608) with the library-side change.


A1763/A1783 005e group appears to be identical and I've validated storm-guard/backup plan functionality working.